### PR TITLE
fix(timer): preserve session state when switching session type

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         shard:
           - name: "timer-flow"
-            tests: "tests/e2e/pages/timer.spec.ts tests/e2e/pages/timer-completion.spec.ts tests/e2e/pages/timer-countdown.spec.ts tests/e2e/pages/timer-reload-contract.spec.ts"
+            tests: "tests/e2e/pages/timer.spec.ts tests/e2e/pages/timer-completion.spec.ts tests/e2e/pages/timer-countdown.spec.ts tests/e2e/pages/timer-reload-contract.spec.ts tests/e2e/pages/session-switch-preservation.spec.ts"
           - name: "timer-ring"
             tests: "tests/e2e/pages/timer-ring-progress.spec.ts tests/e2e/pages/timer-theme.spec.ts tests/e2e/pages/timer-visibility-sync.spec.ts"
           - name: "long-break"

--- a/src/Pomodoro.Web/Services/TimerService.cs
+++ b/src/Pomodoro.Web/Services/TimerService.cs
@@ -196,11 +196,15 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
     {
         await _jsTimerInterop.StopAsync();
 
-        if (_appState.CurrentSession != null)
+        if (_appState.CurrentSession is { WasStarted: true, IsCompleted: false } currentSession)
         {
-            _appState.CurrentSession.IsRunning = false;
-            _appState.CurrentSession.EndAt = null;
-            _pausedSessions[_appState.CurrentSession.Type] = _appState.CurrentSession;
+            currentSession.IsRunning = false;
+            currentSession.EndAt = null;
+            _pausedSessions[currentSession.Type] = currentSession;
+        }
+        else if (_appState.CurrentSession != null)
+        {
+            _pausedSessions.Remove(_appState.CurrentSession.Type);
         }
 
         if (_pausedSessions.TryGetValue(sessionType, out var pausedSession))

--- a/src/Pomodoro.Web/Services/TimerService.cs
+++ b/src/Pomodoro.Web/Services/TimerService.cs
@@ -21,6 +21,7 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
     private readonly SemaphoreSlim _timerCompleteLock = new(Constants.Threading.SemaphoreInitialCount, Constants.Threading.SemaphoreMaxCount);
     private readonly object _timerTickLock = new();
     private bool _isDisposed;
+    private readonly Dictionary<SessionType, TimerSession> _pausedSessions = new();
 
     // ITimerEventPublisher events
     public event Func<TimerCompletedEventArgs, Task>? OnTimerCompleted;
@@ -193,25 +194,36 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
 
     public async Task SwitchSessionTypeAsync(SessionType sessionType)
     {
-        // Stop current timer
         await _jsTimerInterop.StopAsync();
 
-        // Get duration for the new session type using helper method
-        var durationSeconds = _appState.Settings.GetDurationSeconds(sessionType);
-
-        // Create new session (not running, just prepared)
-        _appState.CurrentSession = new TimerSession
+        if (_appState.CurrentSession != null)
         {
-            Id = Guid.NewGuid(),
-            TaskId = _appState.CurrentSession?.TaskId,
-            Type = sessionType,
-            StartedAt = DateTime.UtcNow,
-            DurationSeconds = durationSeconds,
-            RemainingSeconds = durationSeconds,
-            IsRunning = false,
-            IsCompleted = false,
-            EndAt = null
-        };
+            _appState.CurrentSession.IsRunning = false;
+            _appState.CurrentSession.EndAt = null;
+            _pausedSessions[_appState.CurrentSession.Type] = _appState.CurrentSession;
+        }
+
+        if (_pausedSessions.TryGetValue(sessionType, out var pausedSession))
+        {
+            _appState.CurrentSession = pausedSession;
+            _pausedSessions.Remove(sessionType);
+        }
+        else
+        {
+            var durationSeconds = _appState.Settings.GetDurationSeconds(sessionType);
+            _appState.CurrentSession = new TimerSession
+            {
+                Id = Guid.NewGuid(),
+                TaskId = null,
+                Type = sessionType,
+                StartedAt = DateTime.UtcNow,
+                DurationSeconds = durationSeconds,
+                RemainingSeconds = durationSeconds,
+                IsRunning = false,
+                IsCompleted = false,
+                EndAt = null
+            };
+        }
 
         NotifyStateChanged();
     }
@@ -243,8 +255,8 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
     {
         await _jsTimerInterop.StopAsync();
 
-        // Reset tick count to prevent potential overflow
         TickCount = 0;
+        _pausedSessions.Clear();
 
         if (_appState.CurrentSession != null)
         {
@@ -297,6 +309,8 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
         session.IsRunning = false;
         session.IsCompleted = true;
         session.EndAt = null;
+
+        _pausedSessions.Remove(session.Type);
 
         // Reset remaining seconds back to full duration for display
         session.RemainingSeconds = session.DurationSeconds;

--- a/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
@@ -234,7 +234,7 @@ public class SwitchSessionPreservationTests : TimerServiceTests
         var service = CreateService();
         await service.InitializeAsync();
         var taskId = Guid.NewGuid();
-        AppState.CurrentSession!.TaskId = taskId;
+        await service.StartPomodoroAsync(taskId);
 
         await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
         await service.SwitchSessionTypeAsync(SessionType.Pomodoro);

--- a/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
@@ -116,21 +116,19 @@ public partial class TimerServiceTests
         }
 
         [Fact]
-        public async Task SwitchSessionTypeAsync_ToSameSessionType_ResetsTimer()
+        public async Task SwitchSessionTypeAsync_ToSameSessionType_PreservesState()
         {
-            // Arrange
             var service = CreateService();
             await service.InitializeAsync();
             await service.StartPomodoroAsync();
             var durationBefore = service.RemainingTime.TotalSeconds;
 
-            // Act - Switch to same type
             await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
 
-            // Assert - Timer should be reset to duration and not running
             Assert.Equal(SessionType.Pomodoro, service.CurrentSessionType);
             Assert.False(service.IsRunning);
-            Assert.Equal(service.Settings.GetDurationSeconds(SessionType.Pomodoro), service.RemainingTime.TotalSeconds);
+            Assert.True(service.IsPaused);
+            Assert.Equal(durationBefore, service.RemainingTime.TotalSeconds);
         }
 
         [Fact]
@@ -187,30 +185,104 @@ public partial class TimerServiceTests
         [Fact]
         public async Task FullPomodoroCycle_TransitionsCorrectly()
         {
-            // Arrange
             var service = CreateService();
             await service.InitializeAsync();
 
-            // Act & Assert - Start Pomodoro
             await service.StartPomodoroAsync();
             Assert.Equal(SessionType.Pomodoro, service.CurrentSessionType);
             Assert.True(service.IsRunning);
 
-            // Switch to Short Break
             await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
             Assert.Equal(SessionType.ShortBreak, service.CurrentSessionType);
             Assert.False(service.IsRunning);
 
-            // Start Short Break
             await service.StartShortBreakAsync();
             Assert.Equal(SessionType.ShortBreak, service.CurrentSessionType);
             Assert.True(service.IsRunning);
 
-            // Switch back to Pomodoro
             await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
             Assert.Equal(SessionType.Pomodoro, service.CurrentSessionType);
             Assert.False(service.IsRunning);
+            Assert.True(service.IsPaused);
         }
+    }
+}
+
+[Trait("Category", "Service")]
+public class SwitchSessionPreservationTests : TimerServiceTests
+{
+    [Fact]
+    public async Task SwitchAwayAndBack_PreservesRemainingTime()
+    {
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.StartPomodoroAsync();
+
+        AppState.CurrentSession!.RemainingSeconds = 1200;
+
+        await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
+        await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
+
+        Assert.Equal(SessionType.Pomodoro, service.CurrentSessionType);
+        Assert.Equal(1200, service.RemainingSeconds);
+        Assert.True(service.IsPaused);
+    }
+
+    [Fact]
+    public async Task SwitchAwayAndBack_PreservesTaskAssociation()
+    {
+        var service = CreateService();
+        await service.InitializeAsync();
+        var taskId = Guid.NewGuid();
+        AppState.CurrentSession!.TaskId = taskId;
+
+        await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
+        await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
+
+        Assert.Equal(taskId, service.CurrentSession!.TaskId);
+    }
+
+    [Fact]
+    public async Task SwitchToNewType_CreatesFreshSession()
+    {
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.StartPomodoroAsync();
+
+        await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
+
+        Assert.Equal(SessionType.ShortBreak, service.CurrentSessionType);
+        Assert.Equal(service.Settings.GetDurationSeconds(SessionType.ShortBreak), service.RemainingSeconds);
+        Assert.False(service.IsPaused);
+    }
+
+    [Fact]
+    public async Task ResetAsync_ClearsPausedSessions()
+    {
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.StartPomodoroAsync();
+        AppState.CurrentSession!.RemainingSeconds = 1200;
+
+        await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
+        await service.ResetAsync();
+        await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
+
+        Assert.Equal(service.Settings.GetDurationSeconds(SessionType.Pomodoro), service.RemainingSeconds);
+        Assert.False(service.IsPaused);
+    }
+
+    [Fact]
+    public async Task SwitchWhileNotStarted_CreatesFreshSessionForTarget()
+    {
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        await service.SwitchSessionTypeAsync(SessionType.ShortBreak);
+
+        Assert.Equal(SessionType.ShortBreak, service.CurrentSessionType);
+        Assert.Equal(service.Settings.GetDurationSeconds(SessionType.ShortBreak), service.RemainingSeconds);
+        Assert.False(service.IsPaused);
     }
 }
 

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -5,9 +5,9 @@ test.describe('Session Switch Preservation', () => {
   test('should preserve paused state and remaining time when switching session type mid-timer', async ({ page }) => {
     const pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.goto('/');
-    await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
-    await page.reload();
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    await pomodoroPage.resetTimer();
 
     await page.locator('button[aria-label="Start timer"]').click();
     await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
@@ -40,9 +40,9 @@ test.describe('Session Switch Preservation', () => {
       const page = await context.newPage();
       const pomodoroPage = new PomodoroPage(page);
       await pomodoroPage.goto('/');
-      await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
-      await page.reload();
       await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+      await pomodoroPage.resetTimer();
 
       await page.locator('button[aria-label="Start timer"]').click();
       await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -4,7 +4,10 @@ import { PomodoroPage } from '../fixtures/pomodoro.page';
 test.describe('Session Switch Preservation', () => {
   test('should preserve paused state and remaining time when switching session type mid-timer', async ({ page }) => {
     const pomodoroPage = new PomodoroPage(page);
-    await pomodoroPage.fastSetup1MinPomodoro();
+    await pomodoroPage.goto('/');
+    await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
+    await page.reload();
+    await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
     await pomodoroPage.startTimer();
 
     await page.clock.fastForward(3000);
@@ -31,17 +34,22 @@ test.describe('Session Switch Preservation', () => {
   test('should show resume button after switching back to original session type', async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-    const pomodoroPage = new PomodoroPage(page);
-    await pomodoroPage.fastSetup1MinPomodoro();
-    await pomodoroPage.startTimer();
-    await page.clock.fastForward(2000);
+    try {
+      const pomodoroPage = new PomodoroPage(page);
+      await pomodoroPage.goto('/');
+      await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
+      await page.reload();
+      await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+      await pomodoroPage.startTimer();
+      await page.clock.fastForward(2000);
 
-    await pomodoroPage.switchToShortBreak();
-    await pomodoroPage.switchToPomodoro();
+      await pomodoroPage.switchToShortBreak();
+      await pomodoroPage.switchToPomodoro();
 
-    const isResumeVisible = await pomodoroPage.isTimerPaused();
-    expect(isResumeVisible).toBe(true);
-
-    await context.close();
+      const isResumeVisible = await pomodoroPage.isTimerPaused();
+      expect(isResumeVisible).toBe(true);
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -2,12 +2,9 @@ import { test, expect } from '@playwright/test';
 import { PomodoroPage } from '../fixtures/pomodoro.page';
 
 test.describe('Session Switch Preservation', () => {
-  let pomodoroPage: PomodoroPage;
-
   test('should preserve paused state and remaining time when switching session type mid-timer', async ({ page }) => {
-    pomodoroPage = new PomodoroPage(page);
+    const pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.fastSetup1MinPomodoro();
-    await pomodoroPage.resetTimer();
     await pomodoroPage.startTimer();
 
     await page.waitForTimeout(3000);
@@ -31,10 +28,11 @@ test.describe('Session Switch Preservation', () => {
     expect(timeAfterSwitch).toBe(timeBeforeSwitch);
   });
 
-  test('should show resume button (not start button) after switching back to original session type', async ({ page }) => {
-    pomodoroPage = new PomodoroPage(page);
+  test('should show resume button after switching back to original session type', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.fastSetup1MinPomodoro();
-    await pomodoroPage.resetTimer();
     await pomodoroPage.startTimer();
     await page.waitForTimeout(2000);
 
@@ -43,5 +41,7 @@ test.describe('Session Switch Preservation', () => {
 
     const isResumeVisible = await pomodoroPage.isTimerPaused();
     expect(isResumeVisible).toBe(true);
+
+    await context.close();
   });
 });

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -8,8 +8,11 @@ test.describe('Session Switch Preservation', () => {
     await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
     await page.reload();
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
-    await pomodoroPage.startTimer();
 
+    await page.locator('button[aria-label="Start timer"]').click();
+    await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
+
+    await page.clock.install({ time: Date.now() });
     await page.clock.fastForward(3000);
 
     const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
@@ -33,14 +36,18 @@ test.describe('Session Switch Preservation', () => {
 
   test('should show resume button after switching back to original session type', async ({ browser }) => {
     const context = await browser.newContext();
-    const page = await context.newPage();
     try {
+      const page = await context.newPage();
       const pomodoroPage = new PomodoroPage(page);
       await pomodoroPage.goto('/');
       await pomodoroPage.setSettingViaIndexedDB('pomodoroMinutes', 1);
       await page.reload();
       await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
-      await pomodoroPage.startTimer();
+
+      await page.locator('button[aria-label="Start timer"]').click();
+      await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
+
+      await page.clock.install({ time: Date.now() });
       await page.clock.fastForward(2000);
 
       await pomodoroPage.switchToShortBreak();

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -7,8 +7,6 @@ test.describe('Session Switch Preservation', () => {
     await pomodoroPage.goto('/');
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
-    await pomodoroPage.resetTimer();
-
     await page.locator('button[aria-label="Start timer"]').click();
     await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
 
@@ -41,8 +39,6 @@ test.describe('Session Switch Preservation', () => {
       const pomodoroPage = new PomodoroPage(page);
       await pomodoroPage.goto('/');
       await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
-
-      await pomodoroPage.resetTimer();
 
       await page.locator('button[aria-label="Start timer"]').click();
       await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -7,6 +7,7 @@ test.describe('Session Switch Preservation', () => {
   test('should preserve paused state and remaining time when switching session type mid-timer', async ({ page }) => {
     pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.fastSetup1MinPomodoro();
+    await pomodoroPage.resetTimer();
     await pomodoroPage.startTimer();
 
     await page.waitForTimeout(3000);
@@ -30,16 +31,17 @@ test.describe('Session Switch Preservation', () => {
     expect(timeAfterSwitch).toBe(timeBeforeSwitch);
   });
 
-  test('should show reset button (not start button) after switching back to original session type', async ({ page }) => {
+  test('should show resume button (not start button) after switching back to original session type', async ({ page }) => {
     pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.fastSetup1MinPomodoro();
+    await pomodoroPage.resetTimer();
     await pomodoroPage.startTimer();
     await page.waitForTimeout(2000);
 
     await pomodoroPage.switchToShortBreak();
     await pomodoroPage.switchToPomodoro();
 
-    const isResetVisible = await pomodoroPage.isTimerStarted();
-    expect(isResetVisible).toBe(true);
+    const isResumeVisible = await pomodoroPage.isTimerPaused();
+    expect(isResumeVisible).toBe(true);
   });
 });

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -7,6 +7,8 @@ test.describe('Session Switch Preservation', () => {
     await pomodoroPage.goto('/');
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
+    await pomodoroPage.addTask('Switch Test');
+    await pomodoroPage.selectTask('Switch Test');
     await page.locator('button[aria-label="Start timer"]').click();
     await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
 
@@ -40,6 +42,8 @@ test.describe('Session Switch Preservation', () => {
       await pomodoroPage.goto('/');
       await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
+      await pomodoroPage.addTask('Switch Test 2');
+      await pomodoroPage.selectTask('Switch Test 2');
       await page.locator('button[aria-label="Start timer"]').click();
       await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
 

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -7,7 +7,7 @@ test.describe('Session Switch Preservation', () => {
     await pomodoroPage.fastSetup1MinPomodoro();
     await pomodoroPage.startTimer();
 
-    await page.waitForTimeout(3000);
+    await page.clock.fastForward(3000);
 
     const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
 
@@ -34,7 +34,7 @@ test.describe('Session Switch Preservation', () => {
     const pomodoroPage = new PomodoroPage(page);
     await pomodoroPage.fastSetup1MinPomodoro();
     await pomodoroPage.startTimer();
-    await page.waitForTimeout(2000);
+    await page.clock.fastForward(2000);
 
     await pomodoroPage.switchToShortBreak();
     await pomodoroPage.switchToPomodoro();

--- a/tests/e2e/pages/session-switch-preservation.spec.ts
+++ b/tests/e2e/pages/session-switch-preservation.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { PomodoroPage } from '../fixtures/pomodoro.page';
+
+test.describe('Session Switch Preservation', () => {
+  let pomodoroPage: PomodoroPage;
+
+  test('should preserve paused state and remaining time when switching session type mid-timer', async ({ page }) => {
+    pomodoroPage = new PomodoroPage(page);
+    await pomodoroPage.fastSetup1MinPomodoro();
+    await pomodoroPage.startTimer();
+
+    await page.waitForTimeout(3000);
+
+    const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
+
+    await pomodoroPage.switchToShortBreak();
+
+    const timerType = await pomodoroPage.getTimerType();
+    expect(timerType).toContain('BREAK');
+
+    await pomodoroPage.switchToPomodoro();
+
+    const timerTypeAfter = await pomodoroPage.getTimerType();
+    expect(timerTypeAfter).toContain('FOCUSING');
+
+    const isPaused = await pomodoroPage.isTimerPaused();
+    expect(isPaused).toBe(true);
+
+    const timeAfterSwitch = await pomodoroPage.getTimerDisplay();
+    expect(timeAfterSwitch).toBe(timeBeforeSwitch);
+  });
+
+  test('should show reset button (not start button) after switching back to original session type', async ({ page }) => {
+    pomodoroPage = new PomodoroPage(page);
+    await pomodoroPage.fastSetup1MinPomodoro();
+    await pomodoroPage.startTimer();
+    await page.waitForTimeout(2000);
+
+    await pomodoroPage.switchToShortBreak();
+    await pomodoroPage.switchToPomodoro();
+
+    const isResetVisible = await pomodoroPage.isTimerStarted();
+    expect(isResetVisible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #12: Switching session type mid-timer no longer discards the current session
- `SwitchSessionTypeAsync` now pauses and stores the current session, restoring it when switching back
- Preserves remaining time, task association, and WasStarted state
- Clears paused sessions on reset and timer completion
- 5 new unit tests + 2 E2E tests, all 3029 unit tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timer preserves remaining time and task association when switching back to a paused session; switching to a different type starts a fresh, unpaused session with configured duration.
* **Bug Fixes**
  * Completed sessions are no longer restored after switching.
* **Tests**
  * Added/updated unit tests for switch-preservation and reset behavior; added E2E tests validating session-switch preservation.
* **Chores**
  * CI updated to run the new E2E test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->