### PR TITLE
fix(timer): only clear current session on reset instead of all paused sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/**/coverage.cobertura.xml
           fail_ci_if_error: false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         shard:
           - name: "timer-flow"
-            tests: "tests/e2e/pages/timer.spec.ts tests/e2e/pages/timer-completion.spec.ts tests/e2e/pages/timer-countdown.spec.ts tests/e2e/pages/timer-reload-contract.spec.ts tests/e2e/pages/session-switch-preservation.spec.ts"
+            tests: "tests/e2e/pages/timer.spec.ts tests/e2e/pages/timer-completion.spec.ts tests/e2e/pages/timer-countdown.spec.ts tests/e2e/pages/timer-reload-contract.spec.ts tests/e2e/pages/session-switch-preservation.spec.ts tests/e2e/pages/reset-session-isolation.spec.ts"
           - name: "timer-ring"
             tests: "tests/e2e/pages/timer-ring-progress.spec.ts tests/e2e/pages/timer-theme.spec.ts tests/e2e/pages/timer-visibility-sync.spec.ts"
           - name: "long-break"

--- a/src/Pomodoro.Web/Services/TimerService.cs
+++ b/src/Pomodoro.Web/Services/TimerService.cs
@@ -260,11 +260,11 @@ public class TimerService : ITimerService, ITimerEventPublisher, IAsyncDisposabl
         await _jsTimerInterop.StopAsync();
 
         TickCount = 0;
-        _pausedSessions.Clear();
 
         if (_appState.CurrentSession != null)
         {
-            // Use helper method to get duration for current session type
+            _pausedSessions.Remove(_appState.CurrentSession.Type);
+
             var durationSeconds = _appState.Settings.GetDurationSeconds(_appState.CurrentSession.Type);
 
             _appState.CurrentSession.DurationSeconds = durationSeconds;

--- a/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TimerServiceTests/TimerServiceTests.Transitions.cs
@@ -257,7 +257,7 @@ public class SwitchSessionPreservationTests : TimerServiceTests
     }
 
     [Fact]
-    public async Task ResetAsync_ClearsPausedSessions()
+    public async Task ResetAsync_OnlyClearsCurrentSessionPausedState()
     {
         var service = CreateService();
         await service.InitializeAsync();
@@ -268,8 +268,8 @@ public class SwitchSessionPreservationTests : TimerServiceTests
         await service.ResetAsync();
         await service.SwitchSessionTypeAsync(SessionType.Pomodoro);
 
-        Assert.Equal(service.Settings.GetDurationSeconds(SessionType.Pomodoro), service.RemainingSeconds);
-        Assert.False(service.IsPaused);
+        Assert.Equal(1200, service.RemainingSeconds);
+        Assert.True(service.IsPaused);
     }
 
     [Fact]

--- a/tests/e2e/pages/reset-session-isolation.spec.ts
+++ b/tests/e2e/pages/reset-session-isolation.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { PomodoroPage } from '../fixtures/pomodoro.page';
+
+test.describe('Reset Session Isolation', () => {
+  test('resetting one session should not clear other paused sessions', async ({ page }) => {
+    const pomodoroPage = new PomodoroPage(page);
+    await pomodoroPage.goto('/');
+    await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    await pomodoroPage.addTask('Reset Test');
+    await pomodoroPage.selectTask('Reset Test');
+    await page.locator('button[aria-label="Start timer"]').click();
+    await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
+
+    await page.clock.install({ time: Date.now() });
+    await page.clock.fastForward(3000);
+
+    const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
+
+    await pomodoroPage.switchToShortBreak();
+
+    const timerType = await pomodoroPage.getTimerType();
+    expect(timerType).toContain('BREAK');
+
+    await page.locator('button[aria-label="Reset timer"]').click();
+
+    await pomodoroPage.switchToPomodoro();
+
+    const timerTypeAfter = await pomodoroPage.getTimerType();
+    expect(timerTypeAfter).toContain('FOCUSING');
+
+    const isPaused = await pomodoroPage.isTimerPaused();
+    expect(isPaused).toBe(true);
+
+    const timeAfterReset = await pomodoroPage.getTimerDisplay();
+    expect(timeAfterReset).toBe(timeBeforeSwitch);
+  });
+});

--- a/tests/e2e/pages/reset-session-isolation.spec.ts
+++ b/tests/e2e/pages/reset-session-isolation.spec.ts
@@ -14,13 +14,13 @@ test.describe('Reset Session Isolation', () => {
 
     await pomodoroPage.pauseTimer();
 
-    const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
+    const pomodoroTime = await pomodoroPage.getTimerDisplay();
 
     await pomodoroPage.switchToShortBreak();
+    await page.locator('button[aria-label="Start timer"]').click();
+    await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
 
-    const timerType = await pomodoroPage.getTimerType();
-    expect(timerType).toContain('BREAK');
-
+    await pomodoroPage.pauseTimer();
     await page.locator('button[aria-label="Reset timer"]').click();
 
     await pomodoroPage.switchToPomodoro();
@@ -32,6 +32,6 @@ test.describe('Reset Session Isolation', () => {
     expect(isPaused).toBe(true);
 
     const timeAfterReset = await pomodoroPage.getTimerDisplay();
-    expect(timeAfterReset).toBe(timeBeforeSwitch);
+    expect(timeAfterReset).toBe(pomodoroTime);
   });
 });

--- a/tests/e2e/pages/reset-session-isolation.spec.ts
+++ b/tests/e2e/pages/reset-session-isolation.spec.ts
@@ -12,8 +12,7 @@ test.describe('Reset Session Isolation', () => {
     await page.locator('button[aria-label="Start timer"]').click();
     await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
 
-    await page.clock.install({ time: Date.now() });
-    await page.clock.fastForward(3000);
+    await pomodoroPage.pauseTimer();
 
     const timeBeforeSwitch = await pomodoroPage.getTimerDisplay();
 

--- a/tests/e2e/pages/reset-session-isolation.spec.ts
+++ b/tests/e2e/pages/reset-session-isolation.spec.ts
@@ -9,19 +9,17 @@ test.describe('Reset Session Isolation', () => {
 
     await pomodoroPage.addTask('Reset Test');
     await pomodoroPage.selectTask('Reset Test');
-    await page.locator('button[aria-label="Start timer"]').click();
-    await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
+    await pomodoroPage.startTimer();
 
     await pomodoroPage.pauseTimer();
 
     const pomodoroTime = await pomodoroPage.getTimerDisplay();
 
     await pomodoroPage.switchToShortBreak();
-    await page.locator('button[aria-label="Start timer"]').click();
-    await expect(page.locator('button[aria-label="Pause timer"]')).toBeVisible({ timeout: 5000 });
+    await pomodoroPage.startTimer();
 
     await pomodoroPage.pauseTimer();
-    await page.locator('button[aria-label="Reset timer"]').click();
+    await pomodoroPage.resetTimer();
 
     await pomodoroPage.switchToPomodoro();
 


### PR DESCRIPTION
﻿## Summary
- Fixed TimerService.ResetAsync() to only remove the current session's paused state instead of clearing all paused sessions
- Replaced _pausedSessions.Clear() with _pausedSessions.Remove(_appState.CurrentSession.Type)
- Updated unit test to verify other sessions remain paused after reset
- Added E2E test for reset session isolation scenario

Closes #19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset now clears the paused state only for the currently active session type, preserving other session types' paused states.

* **Tests**
  * Added an end-to-end test verifying timer state isolation across session switches and after Reset.
  * Updated unit test expectations to reflect the revised Reset behavior.

* **Chores**
  * Updated CI to run the new e2e scenario and supply an explicit Codecov token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->