### PR TITLE
fix: reports.yml SHARD_LABEL undefined reference error

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -156,7 +156,7 @@ jobs:
           for f in ./e2e-summaries/e2e-summary-shard-*/shard-summary.json; do
             if [ -f "$f" ]; then
               SHARD_NAME=$(node -e "const d=require('$f');console.log(d.shard_name)")
-              SHARD_LABEL=$(node -e "console.log(d.shard_name.charAt(0).toUpperCase() + d.shard_name.slice(1))")
+              SHARD_LABEL=$(node -e "const d=require('$f');console.log(d.shard_name.charAt(0).toUpperCase() + d.shard_name.slice(1))")
               PASSED=$(node -e "const d=require('$f');console.log(d.passed)")
               FAILED=$(node -e "const d=require('$f');console.log(d.failed)")
               SKIPPED=$(node -e "const d=require('$f');console.log(d.skipped)")


### PR DESCRIPTION
## Summary

- Fix eports.yml e2e-gate job: SHARD_LABEL on line 159 used bare d.shard_name without equire(), causing ReferenceError: d is not defined when no E2E summary files exist