### PR TITLE
feat: responsive navigation - mobile bottom tab bar, desktop top nav, history header redesign

### DIFF
--- a/src/Pomodoro.Web/Layout/MainLayout.razor
+++ b/src/Pomodoro.Web/Layout/MainLayout.razor
@@ -14,6 +14,7 @@
                 @foreach (var navLink in LayoutPresenter.GetNavigationLinks())
                 {
                     <NavLink @key="navLink.Href" href="@navLink.Href" Match="@navLink.Match" title="@navLink.Title">
+                        <span class="nav-icon">@navLink.Icon</span>
                         @navLink.Title
                     </NavLink>
                 }

--- a/src/Pomodoro.Web/Layout/MainLayout.razor
+++ b/src/Pomodoro.Web/Layout/MainLayout.razor
@@ -7,11 +7,10 @@
         <div class="header-content-wrapper">
             <div class="header-left">
                 <div class="header-title">
-                    <span class="header-icon">@Constants.Layout.AppIcon</span>
                     <span class="header-text">@Constants.Layout.AppTitle</span>
                 </div>
             </div>
-            <nav class="header-nav">
+            <nav class="header-nav desktop-nav">
                 @foreach (var navLink in LayoutPresenter.GetNavigationLinks())
                 {
                     <NavLink @key="navLink.Href" href="@navLink.Href" Match="@navLink.Match" title="@navLink.Title">
@@ -32,6 +31,16 @@
             </ErrorContent>
         </ErrorBoundary>
     </main>
+
+    <nav class="mobile-nav">
+        @foreach (var navLink in LayoutPresenter.GetNavigationLinks())
+        {
+            <NavLink class="mobile-tab" @key="navLink.Href" href="@navLink.Href" Match="@navLink.Match">
+                <span class="mobile-tab-icon">@navLink.Icon</span>
+                <span class="mobile-tab-label">@navLink.Title</span>
+            </NavLink>
+        }
+    </nav>
 </div>
 
 @code {

--- a/src/Pomodoro.Web/Pages/History.razor
+++ b/src/Pomodoro.Web/Pages/History.razor
@@ -16,14 +16,14 @@ else
         {
             <div class="period-nav">
                 <div class="nav-top">
-                    <HistoryTabs ActiveTab="ActiveTab" OnTabChanged="HandleTabChanged" />
-                    <button class="nav-qbtn @(IsSelectedDateToday ? "active" : "")" @onclick="GoToToday">Today</button>
                     <div class="nav-arrows">
                         <button class="nav-arr" @onclick="GoToPreviousDay" title="Previous day" aria-label="Previous day">&#8592;</button>
                         <span class="period-lbl">@FormattedSelectedDate</span>
                         <button class="nav-arr" @onclick="GoToNextDay" title="Next day" disabled="@IsSelectedDateToday" aria-label="Next day">&#8594;</button>
                     </div>
+                    <HistoryTabs ActiveTab="ActiveTab" OnTabChanged="HandleTabChanged" />
                 </div>
+                <button class="nav-qbtn @(IsSelectedDateToday ? "active" : "")" @onclick="GoToToday">Today</button>
             </div>
 
             <ErrorBoundary @ref="_dailyViewErrorBoundary">
@@ -48,14 +48,14 @@ else
         {
             <div class="period-nav">
                 <div class="nav-top">
-                    <HistoryTabs ActiveTab="ActiveTab" OnTabChanged="HandleTabChanged" />
-                    <button class="nav-qbtn @(IsSelectedWeekCurrent ? "active" : "")" @onclick="GoToThisWeek">This week</button>
                     <div class="nav-arrows">
                         <button class="nav-arr" @onclick="GoToPreviousWeek" title="Previous week" aria-label="Previous week">&#8592;</button>
                         <span class="period-lbl">@FormattedWeekRange</span>
                         <button class="nav-arr" @onclick="GoToNextWeek" title="Next week" disabled="@IsSelectedWeekCurrent" aria-label="Next week">&#8594;</button>
                     </div>
+                    <HistoryTabs ActiveTab="ActiveTab" OnTabChanged="HandleTabChanged" />
                 </div>
+                <button class="nav-qbtn @(IsSelectedWeekCurrent ? "active" : "")" @onclick="GoToThisWeek">This week</button>
             </div>
 
             <ErrorBoundary @ref="_weeklyViewErrorBoundary">

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -107,6 +107,7 @@ input, textarea, [contenteditable="true"] {
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 4px;
     padding: 5px 9px;
     font-size: 12px;
     font-weight: 400;
@@ -117,6 +118,11 @@ input, textarea, [contenteditable="true"] {
     background: transparent;
     cursor: pointer;
     transition: background 0.15s;
+}
+
+.nav-icon {
+    font-size: 14px;
+    line-height: 1;
 }
 
 .header-nav a.active {
@@ -228,6 +234,28 @@ input, textarea, [contenteditable="true"] {
     .mobile-nav {
         display: flex;
     }
+
+    .app-content {
+        padding-bottom: 60px;
+    }
+
+    .header-content-wrapper {
+        justify-content: center;
+    }
+}
+
+.mobile-nav {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--color-background-primary);
+    border-top: 0.5px solid var(--color-border-tertiary);
+    z-index: 100;
+    padding: 6px 0;
+    padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
+}
 
     .app-content {
         padding-bottom: 60px;

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -236,7 +236,7 @@ input, textarea, [contenteditable="true"] {
     }
 
     .app-content {
-        padding-bottom: 60px;
+        padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
     }
 
     .header-content-wrapper {

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -244,24 +244,6 @@ input, textarea, [contenteditable="true"] {
     }
 }
 
-.mobile-nav {
-    display: none;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: var(--color-background-primary);
-    border-top: 0.5px solid var(--color-border-tertiary);
-    z-index: 100;
-    padding: 6px 0;
-    padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
-}
-
-    .app-content {
-        padding-bottom: 60px;
-    }
-}
-
 /* Session Mode Tabs - Segmented Control */
 .mode-tabs {
     display: flex;

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -57,8 +57,8 @@ input, textarea, [contenteditable="true"] {
 /* Header - Minimal Topnav */
 .app-header {
     width: 100%;
-    background: linear-gradient(135deg, var(--color-background-primary) 0%, var(--color-background-secondary) 100%);
-    border-bottom: 1px solid #2d4a6f;
+    background: var(--color-background-primary);
+    border-bottom: 0.5px solid var(--color-border-tertiary);
     padding: 0;
     position: sticky;
     top: 0;
@@ -69,7 +69,7 @@ input, textarea, [contenteditable="true"] {
     max-width: 360px;
     width: 100%;
     margin: 0 auto;
-    padding: 5px 8px;
+    padding: 10px 16px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -87,16 +87,16 @@ input, textarea, [contenteditable="true"] {
 }
 
 .header-text {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 500;
     color: var(--color-text-primary);
 }
 
 .header-icon {
-    font-size: 16px;
+    font-size: 14px;
 }
 
-/* Header Navigation - Text pill buttons */
+/* Header Navigation - Desktop */
 .header-nav {
     display: flex;
     align-items: center;
@@ -107,8 +107,8 @@ input, textarea, [contenteditable="true"] {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 5px 8px;
-    font-size: 16px;
+    padding: 5px 9px;
+    font-size: 12px;
     font-weight: 400;
     color: var(--color-text-secondary);
     text-decoration: none;
@@ -122,6 +122,47 @@ input, textarea, [contenteditable="true"] {
 .header-nav a.active {
     background: var(--color-background-secondary);
     color: var(--color-text-primary);
+    font-weight: 500;
+}
+
+/* Mobile Bottom Navigation */
+.mobile-nav {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--color-background-primary);
+    border-top: 0.5px solid var(--color-border-tertiary);
+    z-index: 100;
+    padding: 6px 0;
+    padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
+}
+
+.mobile-tab {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    flex: 1;
+    padding: 4px 0;
+    text-decoration: none;
+    color: var(--color-text-tertiary);
+    transition: color 0.15s;
+}
+
+.mobile-tab.active {
+    color: var(--pomodoro-color);
+}
+
+.mobile-tab-icon {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.mobile-tab-label {
+    font-size: 10px;
     font-weight: 500;
 }
 
@@ -175,6 +216,21 @@ input, textarea, [contenteditable="true"] {
     }
     .header-content-wrapper {
         max-width: 960px;
+    }
+}
+
+/* Mobile: bottom nav, hide desktop nav */
+@media (max-width: 767px) {
+    .desktop-nav {
+        display: none;
+    }
+
+    .mobile-nav {
+        display: flex;
+    }
+
+    .app-content {
+        padding-bottom: 60px;
     }
 }
 

--- a/src/Pomodoro.Web/wwwroot/css/history.css
+++ b/src/Pomodoro.Web/wwwroot/css/history.css
@@ -10,7 +10,7 @@
     top: 0;
     z-index: 50;
     background: var(--color-background-secondary);
-    padding: 12px 0;
+    padding: 14px 0 0;
     margin-bottom: 4px;
 }
 
@@ -19,18 +19,11 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    position: relative;
-}
-
-.nav-top .nav-qbtn {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
 }
 
 .nav-arrows {
     display: flex;
-    gap: 8px;
+    gap: 4px;
     align-items: center;
 }
 
@@ -42,7 +35,7 @@
     background: var(--color-background-primary);
     color: var(--color-text-secondary);
     cursor: pointer;
-    font-size: 16px;
+    font-size: 13px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -61,15 +54,16 @@
 }
 
 .nav-qbtn {
-    font-size: 14px;
+    font-size: 13px;
     color: var(--color-text-secondary);
     border: 0.5px solid var(--color-border-secondary);
     background: transparent;
     border-radius: var(--border-radius-md);
-    padding: 2px 6px;
+    padding: 4px 10px;
     cursor: pointer;
     font-family: var(--font-sans);
     transition: background 0.15s, color 0.15s;
+    margin-top: 10px;
 }
 
 .nav-qbtn:hover {
@@ -88,10 +82,10 @@
 }
 
 .period-lbl {
-    font-size: 16px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--color-text-primary);
-    margin: 0 4px;
+    margin: 0 6px;
     min-width: 140px;
     text-align: center;
 }

--- a/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
@@ -150,23 +150,19 @@ namespace Pomodoro.Web.Tests.Layout
         [Fact]
         public void MainLayout_RendersCompleteHeaderStructure()
         {
-            // Arrange
             _mockLayoutPresenter.Setup(x => x.GetNavigationLinks()).Returns(Array.Empty<NavLinkData>());
             _mockLayoutPresenter.Setup(x => x.GetCurrentYear()).Returns(2023);
 
-            // Act
             var component = RenderComponent<MainLayout>();
 
-            // Assert - Verify complete header structure is rendered (covers lines9,12,22)
             var headerTitle = component.Find(".header-title");
             Assert.NotNull(headerTitle);
 
             var headerNav = component.Find(".header-nav");
             Assert.NotNull(headerNav);
 
-            // Verify the header-title contains both icon and text spans
             var headerTitleSpans = headerTitle.QuerySelectorAll("span");
-            Assert.True(headerTitleSpans.Length >= 2);
+            Assert.True(headerTitleSpans.Length >= 1);
         }
 
         [Fact]
@@ -247,21 +243,14 @@ namespace Pomodoro.Web.Tests.Layout
         [Fact]
         public void MainLayout_RendersHeaderIconAndTitle()
         {
-            // Arrange
             _mockLayoutPresenter.Setup(x => x.GetNavigationLinks()).Returns(Array.Empty<NavLinkData>());
             _mockLayoutPresenter.Setup(x => x.GetCurrentYear()).Returns(2023);
 
-            // Act
             var component = RenderComponent<MainLayout>();
 
-            // Assert - Verify header icon and title spans (covers lines9-12)
-            // Use actual icon from Constants (🍅)
-            var headerIcon = component.Find(".header-icon");
             var headerText = component.Find(".header-text");
 
-            Assert.NotNull(headerIcon);
             Assert.NotNull(headerText);
-            Assert.Contains("🍅", headerIcon.TextContent);
             Assert.Contains("Pomodoro", headerText.TextContent);
         }
 

--- a/tests/e2e/pages/mobile-nav.spec.ts
+++ b/tests/e2e/pages/mobile-nav.spec.ts
@@ -72,8 +72,8 @@ test.describe('Mobile Header Responsive', () => {
     await pomodoroPage.goto('/');
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
-    const navLink = page.locator('.header-nav a').first();
-    await expect(navLink).toBeVisible();
+    const mobileTab = page.locator('.mobile-tab').first();
+    await expect(mobileTab).toBeVisible();
   });
 });
 

--- a/tests/e2e/pages/mobile-nav.spec.ts
+++ b/tests/e2e/pages/mobile-nav.spec.ts
@@ -44,7 +44,7 @@ test.describe('Mobile Nav Menu', () => {
 });
 
 test.describe('Mobile Header Responsive', () => {
-  test.describe.configure({ timeout: 60000 });
+  test.describe.configure({ mode: 'serial', timeout: 60000 });
 
   test('should render app title inside header-title', async ({ page }) => {
     const pomodoroPage = new PomodoroPage(page);

--- a/tests/e2e/pages/mobile-viewport.spec.ts
+++ b/tests/e2e/pages/mobile-viewport.spec.ts
@@ -40,7 +40,7 @@ test.describe('Mobile Viewport (375x812)', () => {
 
   test('should navigate to about on mobile', async ({ page }) => {
     await pomodoroPage.goto('/');
-    await expect(page.locator('.mobile-tab')).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('.mobile-tab').first()).toBeVisible({ timeout: 30000 });
     await page.locator('.mobile-tab[href="/about"]').click();
     await expect(page.locator('.about-body')).toBeVisible({ timeout: 30000 });
   });

--- a/tests/e2e/pages/mobile-viewport.spec.ts
+++ b/tests/e2e/pages/mobile-viewport.spec.ts
@@ -40,6 +40,7 @@ test.describe('Mobile Viewport (375x812)', () => {
 
   test('should navigate to about on mobile', async ({ page }) => {
     await pomodoroPage.goto('/');
+    await expect(page.locator('.mobile-tab')).toBeVisible({ timeout: 30000 });
     await page.locator('.mobile-tab[href="/about"]').click();
     await expect(page.locator('.about-body')).toBeVisible({ timeout: 30000 });
   });

--- a/tests/e2e/pages/mobile-viewport.spec.ts
+++ b/tests/e2e/pages/mobile-viewport.spec.ts
@@ -40,7 +40,7 @@ test.describe('Mobile Viewport (375x812)', () => {
 
   test('should navigate to about on mobile', async ({ page }) => {
     await pomodoroPage.goto('/');
-    await page.locator('a[href="/about"]').click();
+    await page.locator('.mobile-tab[href="/about"]').click();
     await expect(page.locator('.about-body')).toBeVisible({ timeout: 30000 });
   });
 

--- a/tests/e2e/pages/mobile-viewport.spec.ts
+++ b/tests/e2e/pages/mobile-viewport.spec.ts
@@ -58,9 +58,10 @@ test.describe('Mobile Viewport (375x812)', () => {
     await expect(page.locator('.step-input').first()).toBeVisible();
   });
 
-  test('should show navigation links on mobile', async ({ page }) => {
+  test('should show navigation on mobile', async ({ page }) => {
     await pomodoroPage.goto('/');
-    await expect(page.locator('.header-nav')).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('.mobile-nav')).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('.mobile-tab')).toHaveCount(4);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Mobile bottom tab bar** (<768px): Fixed bottom nav with emoji icons + text labels, active tab highlighted in coral, safe-area-inset-bottom support
- **Desktop top navbar** (>=768px): Brand text left, nav links right with active state styling
- **History header redesign**: Navigation arrows moved to left, Daily/Weekly toggle moved to right, "Today"/"This week" quick-jump button placed below nav row
- **Header styling update**: Flat background (no gradient), 0.5px borders, 13-14px fonts matching design mock
- Removed tomato emoji from brand header

## Test plan
- [x] All 3318 unit tests pass
- [x] dotnet format --verify-no-changes passes
- [x] Updated 2 unit tests (MainLayout header structure)
- [x] Updated 2 E2E tests (mobile nav/viewport selectors)

Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fixed mobile bottom navigation with tab-style icons and labels.

* **Style**
  * Simplified header styling: solid background, tightened spacing and reduced typography; header icon removed from title area.
  * Desktop navigation spacing adjusted; desktop links now display icons alongside labels.
  * History page period navigation layout and control positioning updated.

* **Tests**
  * Responsive tests updated to target mobile tabs, verify mobile nav visibility/count, run serially, and relax header-icon assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->