### PR TITLE
fix: address CodeRabbit and Codecov review feedback

### DIFF
--- a/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
+++ b/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
@@ -91,6 +91,16 @@
         }
     }
 
+    private static string GetSyncSuccessMessage(SyncResult result)
+    {
+        if (result.Action == SyncAction.Pushed)
+            return Constants.SyncMessages.SyncPushSuccess;
+        if (result.Action == SyncAction.Pulled)
+            return string.Format(Constants.SyncMessages.SyncPullSuccess,
+                result.ActivitiesImported, result.TasksImported);
+        return Constants.SyncMessages.AlreadyUpToDate;
+    }
+
     private async Task SyncNow()
     {
         _isSyncing = true;
@@ -102,15 +112,7 @@
 
             if (result.Success)
             {
-                string message;
-                if (result.Action == SyncAction.Pushed)
-                    message = Constants.SyncMessages.SyncPushSuccess;
-                else if (result.Action == SyncAction.Pulled)
-                    message = string.Format(Constants.SyncMessages.SyncPullSuccess,
-                        result.ActivitiesImported, result.TasksImported);
-                else
-                    message = Constants.SyncMessages.AlreadyUpToDate;
-                await ShowToast(message);
+                await ShowToast(GetSyncSuccessMessage(result));
             }
             else if (result.ErrorMessage == Constants.SyncMessages.ReconnectRequired)
             {
@@ -121,15 +123,7 @@
                     result = await CloudSyncService.SyncNowAsync();
                     if (result.Success)
                     {
-                        string message;
-                        if (result.Action == SyncAction.Pushed)
-                            message = Constants.SyncMessages.SyncPushSuccess;
-                        else if (result.Action == SyncAction.Pulled)
-                            message = string.Format(Constants.SyncMessages.SyncPullSuccess,
-                                result.ActivitiesImported, result.TasksImported);
-                        else
-                            message = Constants.SyncMessages.AlreadyUpToDate;
-                        await ShowToast(message);
+                        await ShowToast(GetSyncSuccessMessage(result));
                     }
                     else
                     {

--- a/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
@@ -286,9 +286,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -303,9 +303,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -320,9 +320,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -340,9 +340,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.ConnectAsync(It.IsAny<string>()), Times.Once);
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Exactly(2));
@@ -361,9 +361,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.ConnectAsync(It.IsAny<string>()), Times.Once);
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Exactly(2));

--- a/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
@@ -162,7 +162,7 @@ namespace Pomodoro.Web.Tests.Layout
             Assert.NotNull(headerNav);
 
             var headerTitleSpans = headerTitle.QuerySelectorAll("span");
-            Assert.True(headerTitleSpans.Length >= 1);
+            Assert.Equal(1, headerTitleSpans.Length);
         }
 
         [Fact]

--- a/tests/Pomodoro.Web.Tests/CoveragePush98Tests.cs
+++ b/tests/Pomodoro.Web.Tests/CoveragePush98Tests.cs
@@ -244,8 +244,8 @@ public class CloudSyncSettingsPullBranchTests : TestContext
 
         cut.Find("button.sec-btn").Click();
 
-        await Task.Delay(100);
-        toastMessage.Should().Be(Constants.SyncMessages.AlreadyUpToDate);
+        cut.WaitForAssertion(() =>
+            toastMessage.Should().Be(Constants.SyncMessages.AlreadyUpToDate));
     }
 }
 

--- a/tests/Pomodoro.Web.Tests/Services/BranchCoverageServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/BranchCoverageServiceTests.cs
@@ -8,6 +8,7 @@ namespace Pomodoro.Web.Tests.Services;
 [Trait("Category", "Service")]
 public partial class ActivityServiceTests
 {
+    [Trait("Category", "Service")]
     public class NullActivitiesBranchTests : ActivityServiceTests
     {
         [Fact]
@@ -22,12 +23,13 @@ public partial class ActivityServiceTests
         }
     }
 
+    [Trait("Category", "Service")]
     public class ShortBreakOnlyDistributionTests : ActivityServiceTests
     {
         [Fact]
         public async Task GetTimeDistribution_OnlyShortBreaks_NoLongBreakEntry()
         {
-            var date = new DateTime(2024, 6, 15);
+            var date = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Local);
             var activities = new List<ActivityRecord>
             {
                 new() { Id = Guid.NewGuid(), Type = SessionType.ShortBreak, CompletedAt = date, DurationMinutes = 5 }
@@ -50,6 +52,7 @@ public partial class ActivityServiceTests
 [Trait("Category", "Service")]
 public partial class TaskServiceTests
 {
+    [Trait("Category", "Service")]
     public class MaxLengthNameTests : TaskServiceTests
     {
         [Fact]

--- a/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
+++ b/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
@@ -549,10 +549,7 @@ public partial class TimerServiceCloudSyncTests
 
         timerService.OnTimerTickJs();
 
-        for (var i = 0; i < 10; i++)
-        {
-            await Task.Delay(100);
-        }
+        await Task.Delay(200);
 
         mockCloudSync.Verify(c => c.ScheduleSyncAsync(), Times.Once);
     }


### PR DESCRIPTION
## Summary

- Await reflected SyncNow Task in BranchCoverageTests (5 locations)
- Replace Task.Delay with WaitForAssertion in CoveragePush98Tests
- Add [Trait] to nested test classes in BranchCoverageServiceTests
- Use DateTimeKind.Local to prevent timezone-dependent failures
- Tighten header span assertion in MainLayoutTests
- Extract GetSyncSuccessMessage helper in CloudSyncSettings
- Reduce polling loop to single Task.Delay in BranchCoverageTests2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cloud sync test reliability with better assertion strategies and timing mechanisms.
  * Enhanced header structure validation with stricter test assertions.
  * Added test categorization for better organization.

* **Chores**
  * Refactored sync message handling to reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->