### PR TITLE
Revert: undo PR #36 merge on main

### DIFF
--- a/tests/Pomodoro.Web.Tests/Services/SafeTaskRunnerTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/SafeTaskRunnerTests.cs
@@ -25,7 +25,7 @@ public class SafeTaskRunnerTests
             var completed = await Task.WhenAny(tcs.Task, Task.Delay(5000));
 
             Assert.True(completed == tcs.Task);
-            Assert.True(await tcs.Task);
+            Assert.True(tcs.Task.Result);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Reverts the last merge on main (4e6e6af) from PR #36 (develop → main release merge) due to deployment issues.

Rolls back 1 change: SafeTaskRunnerTests.cs (reverts wait back to Task.Result).

Closes #39