### PR TITLE
feat: add manual preview deployment for any branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
   deployments: write
 
 concurrency:
-  group: deploy-${{ github.ref_name }}
+  group: deploy-${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,18 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy as preview'
+        required: true
+        default: 'develop'
 
 permissions:
   contents: read
   deployments: write
 
 concurrency:
-  group: deploy-production
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -41,9 +48,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.deployment-url }}
+    environment: ${{ github.event_name == 'push' && 'production' || 'preview' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -57,5 +62,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: pomodoro
-          branch: main
+          branch: ${{ github.event_name == 'push' && 'main' || inputs.branch }}
           directory: publish/wwwroot

--- a/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
+++ b/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
@@ -96,8 +96,9 @@
         if (result.Action == SyncAction.Pushed)
             return Constants.SyncMessages.SyncPushSuccess;
         if (result.Action == SyncAction.Pulled)
-            return string.Format(Constants.SyncMessages.SyncPullSuccess,
-                result.ActivitiesImported, result.TasksImported);
+            return Constants.SyncMessages.SyncPullSuccess
+                .Replace("{ActivityCount}", result.ActivitiesImported.ToString())
+                .Replace("{TaskCount}", result.TasksImported.ToString());
         return Constants.SyncMessages.AlreadyUpToDate;
     }
 

--- a/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
+++ b/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
@@ -91,6 +91,16 @@
         }
     }
 
+    private static string GetSyncSuccessMessage(SyncResult result)
+    {
+        if (result.Action == SyncAction.Pushed)
+            return Constants.SyncMessages.SyncPushSuccess;
+        if (result.Action == SyncAction.Pulled)
+            return string.Format(Constants.SyncMessages.SyncPullSuccess,
+                result.ActivitiesImported, result.TasksImported);
+        return Constants.SyncMessages.AlreadyUpToDate;
+    }
+
     private async Task SyncNow()
     {
         _isSyncing = true;
@@ -102,15 +112,7 @@
 
             if (result.Success)
             {
-                string message;
-                if (result.Action == SyncAction.Pushed)
-                    message = Constants.SyncMessages.SyncPushSuccess;
-                else if (result.Action == SyncAction.Pulled)
-                    message = string.Format(Constants.SyncMessages.SyncPullSuccess,
-                        result.ActivitiesImported, result.TasksImported);
-                else
-                    message = Constants.SyncMessages.AlreadyUpToDate;
-                await ShowToast(message);
+                await ShowToast(GetSyncSuccessMessage(result));
             }
             else if (result.ErrorMessage == Constants.SyncMessages.ReconnectRequired)
             {
@@ -121,15 +123,7 @@
                     result = await CloudSyncService.SyncNowAsync();
                     if (result.Success)
                     {
-                        string message;
-                        if (result.Action == SyncAction.Pushed)
-                            message = Constants.SyncMessages.SyncPushSuccess;
-                        else if (result.Action == SyncAction.Pulled)
-                            message = string.Format(Constants.SyncMessages.SyncPullSuccess,
-                                result.ActivitiesImported, result.TasksImported);
-                        else
-                            message = Constants.SyncMessages.AlreadyUpToDate;
-                        await ShowToast(message);
+                        await ShowToast(GetSyncSuccessMessage(result));
                     }
                     else
                     {

--- a/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
@@ -286,9 +286,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -303,9 +303,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -320,9 +320,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Once);
     }
@@ -340,9 +340,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.ConnectAsync(It.IsAny<string>()), Times.Once);
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Exactly(2));
@@ -361,9 +361,9 @@ public class CloudSyncSettingsBranchTests : TestContext
 
         var cut = RenderComponent<Pomodoro.Web.Components.Settings.CloudSyncSettings>();
 
-        await cut.InvokeAsync(() => cut.Instance.GetType()
+        await cut.InvokeAsync(() => (Task)cut.Instance.GetType()
             .GetMethod("SyncNow", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(cut.Instance, null));
+            .Invoke(cut.Instance, null)!);
 
         _cloudSyncServiceMock.Verify(x => x.ConnectAsync(It.IsAny<string>()), Times.Once);
         _cloudSyncServiceMock.Verify(x => x.SyncNowAsync(), Times.Exactly(2));

--- a/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
@@ -162,7 +162,7 @@ namespace Pomodoro.Web.Tests.Layout
             Assert.NotNull(headerNav);
 
             var headerTitleSpans = headerTitle.QuerySelectorAll("span");
-            Assert.True(headerTitleSpans.Length >= 1);
+            Assert.Equal(1, headerTitleSpans.Length);
         }
 
         [Fact]

--- a/tests/Pomodoro.Web.Tests/CoveragePush98Tests.cs
+++ b/tests/Pomodoro.Web.Tests/CoveragePush98Tests.cs
@@ -244,8 +244,8 @@ public class CloudSyncSettingsPullBranchTests : TestContext
 
         cut.Find("button.sec-btn").Click();
 
-        await Task.Delay(100);
-        toastMessage.Should().Be(Constants.SyncMessages.AlreadyUpToDate);
+        cut.WaitForAssertion(() =>
+            toastMessage.Should().Be(Constants.SyncMessages.AlreadyUpToDate));
     }
 }
 

--- a/tests/Pomodoro.Web.Tests/Services/BranchCoverageServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/BranchCoverageServiceTests.cs
@@ -8,6 +8,7 @@ namespace Pomodoro.Web.Tests.Services;
 [Trait("Category", "Service")]
 public partial class ActivityServiceTests
 {
+    [Trait("Category", "Service")]
     public class NullActivitiesBranchTests : ActivityServiceTests
     {
         [Fact]
@@ -22,12 +23,13 @@ public partial class ActivityServiceTests
         }
     }
 
+    [Trait("Category", "Service")]
     public class ShortBreakOnlyDistributionTests : ActivityServiceTests
     {
         [Fact]
         public async Task GetTimeDistribution_OnlyShortBreaks_NoLongBreakEntry()
         {
-            var date = new DateTime(2024, 6, 15);
+            var date = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Local);
             var activities = new List<ActivityRecord>
             {
                 new() { Id = Guid.NewGuid(), Type = SessionType.ShortBreak, CompletedAt = date, DurationMinutes = 5 }
@@ -50,6 +52,7 @@ public partial class ActivityServiceTests
 [Trait("Category", "Service")]
 public partial class TaskServiceTests
 {
+    [Trait("Category", "Service")]
     public class MaxLengthNameTests : TaskServiceTests
     {
         [Fact]

--- a/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
+++ b/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
@@ -547,9 +547,14 @@ public partial class TimerServiceCloudSyncTests
         appState.CurrentSession!.RemainingSeconds = 1;
         appState.CurrentSession!.EndAt = DateTime.UtcNow.AddSeconds(1);
 
+        var syncCalled = new TaskCompletionSource<bool>();
+        mockCloudSync.Setup(c => c.ScheduleSyncAsync())
+            .Callback(() => syncCalled.TrySetResult(true))
+            .Returns(Task.CompletedTask);
+
         timerService.OnTimerTickJs();
 
-        await Task.Delay(200);
+        await syncCalled.Task;
 
         mockCloudSync.Verify(c => c.ScheduleSyncAsync(), Times.Once);
     }

--- a/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
+++ b/tests/Pomodoro.Web.Tests/Services/BranchCoverageTests2.cs
@@ -549,10 +549,7 @@ public partial class TimerServiceCloudSyncTests
 
         timerService.OnTimerTickJs();
 
-        for (var i = 0; i < 10; i++)
-        {
-            await Task.Delay(100);
-        }
+        await Task.Delay(200);
 
         mockCloudSync.Verify(c => c.ScheduleSyncAsync(), Times.Once);
     }


### PR DESCRIPTION
## Summary

- Auto-deploy to production on push to \main\ (unchanged)
- Manual \workflow_dispatch\ to deploy any branch as preview via Cloudflare Pages
- Enter branch name in workflow input (defaults to \develop\)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud sync now shows consistent, accurate success toasts for push/pull and up-to-date outcomes.

* **Tests**
  * Improved test reliability and synchronization checks for cloud sync and layout behavior.

* **Chores**
  * Streamlined internal messaging logic to remove duplication.
  * Updated deployment workflow to support manual dispatches and better concurrency control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->