### PR TITLE
ci: add patch coverage threshold and codecov verbose logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/**/coverage.cobertura.xml
           fail_ci_if_error: false
+          verbose: true
 
   e2e:
     needs: build

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,7 @@ coverage:
     patch:
       default:
         target: 98%
+        threshold: 0.5%
 parsers:
   cobertura:
     partials_as_hits: false


### PR DESCRIPTION
## Summary
- Add `patch_threshold: 0.5%` to codecov.yml to prevent flaky CI failures on PRs with minimal changes
- Add `verbose: true` to codecov-action for better debugging in CI logs

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration processes with improved coverage reporting and stricter code quality thresholds to maintain project standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->