### PR TITLE
fix: mobile header - show logo with name and match menu text size to desktop

### DIFF
--- a/src/Pomodoro.Web/Layout/MainLayout.razor
+++ b/src/Pomodoro.Web/Layout/MainLayout.razor
@@ -7,6 +7,7 @@
         <div class="header-content-wrapper">
             <div class="header-left">
                 <div class="header-title">
+                    <span class="header-icon">@Constants.Layout.AppIcon</span>
                     <span class="header-text">@Constants.Layout.AppTitle</span>
                 </div>
             </div>

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -87,13 +87,13 @@ input, textarea, [contenteditable="true"] {
 }
 
 .header-text {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 500;
     color: var(--color-text-primary);
 }
 
 .header-icon {
-    font-size: 14px;
+    font-size: 16px;
 }
 
 /* Header Navigation - Desktop */
@@ -108,8 +108,8 @@ input, textarea, [contenteditable="true"] {
     align-items: center;
     justify-content: center;
     gap: 4px;
-    padding: 5px 9px;
-    font-size: 12px;
+    padding: 5px 8px;
+    font-size: 16px;
     font-weight: 400;
     color: var(--color-text-secondary);
     text-decoration: none;

--- a/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/Layout/MainLayoutTests.cs
@@ -162,7 +162,7 @@ namespace Pomodoro.Web.Tests.Layout
             Assert.NotNull(headerNav);
 
             var headerTitleSpans = headerTitle.QuerySelectorAll("span");
-            Assert.Equal(1, headerTitleSpans.Length);
+            Assert.Equal(2, headerTitleSpans.Length);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Restore the Pomodoro icon to the header title that was lost during the responsive navigation redesign (PR #34)
- Match header text size (14px to 16px), header icon size (14px to 16px), and nav link font size (12px to 16px) to main branch sizing
- Update MainLayout test to expect 2 spans in header-title (icon + text)

Closes #49
Closes #45
Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app icon display in the header title area alongside the application title.

* **Style**
  * Increased header text and icon font sizes to 16px.
  * Enhanced navigation link styling with larger font size and adjusted spacing.

* **Tests**
  * Updated header structure test assertions to reflect the new layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->