### PR TITLE
fix: mobile responsiveness for content pages on small viewports

### DIFF
--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -38,6 +38,7 @@ body {
     -moz-user-select: none;
     user-select: none;
     caret-color: transparent;
+    overflow-x: hidden;
 }
 
 input, textarea, [contenteditable="true"] {
@@ -1041,14 +1042,58 @@ input, textarea, [contenteditable="true"] {
     .mode-tabs {
         margin: 8px 8px 7px;
     }
+    .mode-tabs button {
+        padding: 8px 0;
+        font-size: 14px;
+    }
     .timer-card {
         margin: 0 8px 8px;
+    }
+    .ring-area {
+        width: 150px;
+        height: 150px;
+    }
+    .timer-time {
+        font-size: 36px;
+    }
+    .timer-mode-label {
+        font-size: 13px;
+    }
+    .ibtn.lg {
+        width: 52px;
+        height: 52px;
     }
     .task-card {
         margin: 0 8px 8px;
     }
     .pip-btn {
         display: none;
+    }
+    .step-btn {
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+    }
+    .tog {
+        width: 44px;
+        height: 24px;
+        border-radius: 12px;
+    }
+    .tog-k {
+        width: 18px;
+        height: 18px;
+        top: 2px;
+        left: 2px;
+    }
+    .tog.on .tog-k {
+        left: 22px;
+    }
+    .consent-modal {
+        max-width: 100%;
+        margin: 0 8px;
+    }
+    .btn-option {
+        padding: 14px 12px;
     }
 }
 

--- a/src/Pomodoro.Web/wwwroot/css/history.css
+++ b/src/Pomodoro.Web/wwwroot/css/history.css
@@ -711,4 +711,23 @@
         grid-template-columns: 2rem 3rem 1fr 2.5rem;
         gap: 0.75rem;
     }
+    .nav-arr {
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+    }
+    .nav-qbtn {
+        padding: 6px 12px;
+        font-size: 13px;
+    }
+    .chart-row {
+        grid-template-columns: 140px 1fr;
+        gap: 12px;
+    }
+    .donut-wrap {
+        max-width: 140px;
+    }
+    .donut-val {
+        font-size: 18px;
+    }
 }


### PR DESCRIPTION
## Summary
- Scale timer ring down (180px to 150px) and timer text (42px to 36px) on viewports under 480px
- Increase touch targets: stepper buttons (24px to 32px), toggle switch (34px to 44px), mode tab padding (6px to 8px), nav arrows (26px to 32px), consent option padding (12px to 14px)
- Scale donut chart down on mobile (180px to 140px)
- Add overflow-x hidden to prevent horizontal scroll on any page
- All 3318 unit tests passing

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile layout on screens 480px and smaller with refined spacing and sizing of buttons, timer display, and navigation controls
  * Enhanced visibility of charts and adjusted UI element dimensions for improved mobile device usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->