### PR TITLE
test: increase coverage to 99.3% with 83 new unit tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,11 @@ coverage:
   status:
     project:
       default:
-        target: 99%
+        target: 99.5%
         threshold: 0.5%
     patch:
       default:
-        target: 99%
+        target: 99.5%
         threshold: 0.5%
 parsers:
   cobertura:

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,11 @@ coverage:
   status:
     project:
       default:
-        target: 98%
+        target: 99%
         threshold: 0.5%
     patch:
       default:
-        target: 98%
+        target: 99%
         threshold: 0.5%
 parsers:
   cobertura:

--- a/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/BranchCoverageTests.cs
@@ -127,6 +127,15 @@ public class DataManagementSettingsBranchTests : TestHelper
 
         Assert.Contains("Import successful", cut.Markup);
     }
+
+    [Fact]
+    public void Render_WithIsImportingTrue_ShowsImportingText()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Components.Settings.DataManagementSettings>(
+            parameters => parameters.Add(p => p.IsImporting, true));
+
+        Assert.Contains("Importing...", cut.Markup);
+    }
 }
 
 [Trait("Category", "Component")]

--- a/tests/Pomodoro.Web.Tests/Components/History/WeeklyMiniChartTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/History/WeeklyMiniChartTests.cs
@@ -630,9 +630,9 @@ public partial class WeeklyMiniChartTests : TestContext
     [Fact]
     public Task WeeklyMiniChart_OnParametersSetAsync_SameData_SkipsReRender()
     {
-        var jsRuntimeMock = new Mock<IJSRuntime>();
-        Services.AddSingleton<IJSRuntime>(jsRuntimeMock.Object);
-        Services.AddSingleton<IChartService>(new ChartService(jsRuntimeMock.Object));
+        var testJsRuntime = new TestJsRuntime();
+        Services.AddSingleton<IJSRuntime>(testJsRuntime);
+        Services.AddSingleton<IChartService>(new ChartService(testJsRuntime));
         Services.AddSingleton(new ChartDataFormatter());
 
         var weekStart = DateTime.Today;
@@ -644,17 +644,40 @@ public partial class WeeklyMiniChartTests : TestContext
             .Add(p => p.BreakDailyMinutes, breakData)
             .Add(p => p.WeekStartDate, weekStart));
 
-        var initialCallCount = jsRuntimeMock.Invocations.Count;
+        var initialCallCount = testJsRuntime.InvokeCount;
 
         cut.SetParametersAndRender(parameters => parameters
             .Add(p => p.DailyFocusMinutes, new Dictionary<DateTime, int> { { weekStart, 100 } })
             .Add(p => p.BreakDailyMinutes, new Dictionary<DateTime, int> { { weekStart, 20 } })
             .Add(p => p.WeekStartDate, weekStart));
 
-        Assert.Equal(initialCallCount, jsRuntimeMock.Invocations.Count);
+        Assert.Equal(initialCallCount, testJsRuntime.InvokeCount);
         return Task.CompletedTask;
     }
 
     #endregion
+}
+
+internal class TestJsRuntime : IJSRuntime
+{
+    public int InvokeCount { get; private set; }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken = default)
+    {
+        InvokeCount++;
+        return default;
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        InvokeCount++;
+        return default;
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        InvokeCount++;
+        return default;
+    }
 }
 

--- a/tests/Pomodoro.Web.Tests/Components/History/WeeklyMiniChartTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/History/WeeklyMiniChartTests.cs
@@ -627,6 +627,34 @@ public partial class WeeklyMiniChartTests : TestContext
         return Task.CompletedTask;
     }
 
+    [Fact]
+    public Task WeeklyMiniChart_OnParametersSetAsync_SameData_SkipsReRender()
+    {
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        Services.AddSingleton<IJSRuntime>(jsRuntimeMock.Object);
+        Services.AddSingleton<IChartService>(new ChartService(jsRuntimeMock.Object));
+        Services.AddSingleton(new ChartDataFormatter());
+
+        var weekStart = DateTime.Today;
+        var focusData = new Dictionary<DateTime, int> { { weekStart, 100 } };
+        var breakData = new Dictionary<DateTime, int> { { weekStart, 20 } };
+
+        var cut = RenderComponent<WeeklyMiniChart>(parameters => parameters
+            .Add(p => p.DailyFocusMinutes, focusData)
+            .Add(p => p.BreakDailyMinutes, breakData)
+            .Add(p => p.WeekStartDate, weekStart));
+
+        var initialCallCount = jsRuntimeMock.Invocations.Count;
+
+        cut.SetParametersAndRender(parameters => parameters
+            .Add(p => p.DailyFocusMinutes, new Dictionary<DateTime, int> { { weekStart, 100 } })
+            .Add(p => p.BreakDailyMinutes, new Dictionary<DateTime, int> { { weekStart, 20 } })
+            .Add(p => p.WeekStartDate, weekStart));
+
+        Assert.Equal(initialCallCount, jsRuntimeMock.Invocations.Count);
+        return Task.CompletedTask;
+    }
+
     #endregion
 }
 

--- a/tests/Pomodoro.Web.Tests/Components/TaskEditPanelTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskEditPanelTests.cs
@@ -37,7 +37,8 @@ public class TaskEditPanelTests : TestContext
         var cut = RenderComponent<TaskEditPanel>(parameters =>
             parameters.Add(p => p.Task, task));
 
-        cut.Markup.Should().Contain("Daily");
+        var select = cut.Find("select.tep-select");
+        select.GetAttribute("value").Should().Be(RepeatType.Daily.ToString());
         cut.Markup.Should().Contain("Pause");
     }
 

--- a/tests/Pomodoro.Web.Tests/Components/TaskEditPanelTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskEditPanelTests.cs
@@ -1,0 +1,283 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Pomodoro.Web.Components.Tasks;
+using Pomodoro.Web.Models;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Components;
+
+[Trait("Category", "Component")]
+public class TaskEditPanelTests : TestContext
+{
+    private static TaskItem CreateTask(Action<TaskItem>? configure = null)
+    {
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Test Task" };
+        configure?.Invoke(task);
+        return task;
+    }
+
+    [Fact]
+    public void OnInitialized_WithNullRepeat_SetsDefaults()
+    {
+        var task = CreateTask();
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Markup.Should().Contain("None");
+        cut.Markup.Should().Contain("Schedule");
+        cut.Markup.Should().NotContain("tep-weekdays");
+        cut.Markup.Should().NotContain("Pause");
+    }
+
+    [Fact]
+    public void OnInitialized_WithDailyRepeat_ShowsDailySelected()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule { Type = RepeatType.Daily });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Markup.Should().Contain("Daily");
+        cut.Markup.Should().Contain("Pause");
+    }
+
+    [Fact]
+    public void ToggleWeekday_TogglesDaySelection()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Weekly,
+            Weekdays = [DayOfWeek.Monday]
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        var buttons = cut.FindAll(".tep-weekday-btn");
+        buttons.Count.Should().Be(7);
+        cut.FindAll(".tep-weekday-btn.active").Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void OnInitialized_WithCustomRepeat_ShowsCustomDaysInput()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Custom,
+            CustomDays = 3
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Markup.Should().Contain("Every");
+        cut.Markup.Should().Contain("days");
+    }
+
+    [Fact]
+    public void OnInitialized_WithMonthlyRepeat_ShowsMonthlyDayInput()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Monthly,
+            MonthlyDay = 15
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Markup.Should().Contain("Day");
+        cut.Markup.Should().Contain("of month");
+    }
+
+    [Fact]
+    public void OnInitialized_WithScheduledDate_ShowsDate()
+    {
+        var date = new DateTime(2026, 6, 15);
+        var task = CreateTask(t => t.ScheduledDate = date);
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Markup.Should().Contain("2026-06-15");
+    }
+
+    [Fact]
+    public void OnInitialized_WithPausedRepeat_ShowsPauseActive()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Daily,
+            IsPaused = true
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        cut.Find(".tep-toggle").ClassList.Should().Contain("active");
+    }
+
+    [Fact]
+    public void HandleSave_WithNoneType_SetsRepeatToNull()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule { Type = RepeatType.Daily });
+        TaskItem? savedTask = null;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnSave, EventCallback.Factory.Create<TaskItem>(this, t => savedTask = t)));
+
+        var select = cut.Find("select.tep-select");
+        select.Change("None");
+        cut.Find(".tep-save-btn").Click();
+
+        savedTask.Should().NotBeNull();
+        savedTask!.Repeat.Should().BeNull();
+    }
+
+    [Fact]
+    public void HandleSave_WithExistingRepeat_PreservesMetadata()
+    {
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 12, 31);
+        var lastCompleted = new DateTime(2026, 5, 1);
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Daily,
+            StartDate = startDate,
+            EndDate = endDate,
+            LastCompletedDate = lastCompleted,
+            CustomDays = 5
+        });
+        TaskItem? savedTask = null;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnSave, EventCallback.Factory.Create<TaskItem>(this, t => savedTask = t)));
+
+        cut.Find(".tep-save-btn").Click();
+
+        savedTask.Should().NotBeNull();
+        savedTask!.Repeat.Should().NotBeNull();
+        savedTask.Repeat!.StartDate.Should().Be(startDate);
+        savedTask.Repeat.EndDate.Should().Be(endDate);
+        savedTask.Repeat.LastCompletedDate.Should().Be(lastCompleted);
+        savedTask.Repeat.NextOccurrence.Should().BeNull();
+    }
+
+    [Fact]
+    public void HandleSave_WithNewRepeat_CreatesFreshRule()
+    {
+        var task = CreateTask();
+        TaskItem? savedTask = null;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnSave, EventCallback.Factory.Create<TaskItem>(this, t => savedTask = t)));
+
+        var select = cut.Find("select.tep-select");
+        select.Change("Weekly");
+        cut.Find(".tep-save-btn").Click();
+
+        savedTask.Should().NotBeNull();
+        savedTask!.Repeat.Should().NotBeNull();
+        savedTask.Repeat!.Type.Should().Be(RepeatType.Weekly);
+    }
+
+    [Fact]
+    public void HandleSave_SetsScheduledDate()
+    {
+        var task = CreateTask();
+        TaskItem? savedTask = null;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnSave, EventCallback.Factory.Create<TaskItem>(this, t => savedTask = t)));
+
+        cut.Find("input[type=\"date\"]").Change("2026-07-04");
+        cut.Find(".tep-save-btn").Click();
+
+        savedTask.Should().NotBeNull();
+        savedTask!.ScheduledDate.Should().Be(new DateTime(2026, 7, 4));
+    }
+
+    [Fact]
+    public void HandleCancel_InvokesOnCancel()
+    {
+        var task = CreateTask();
+        var cancelled = false;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnCancel, EventCallback.Factory.Create(this, () => cancelled = true)));
+
+        cut.Find(".tep-cancel-btn").Click();
+
+        cancelled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnInitialized_WithZeroCustomDays_UsesDefault()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Custom,
+            CustomDays = 0
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        var input = cut.Find("input[type=\"number\"]");
+        int.TryParse(input.GetAttribute("value"), out var days).Should().BeTrue();
+        days.Should().Be(Constants.Repeat.DefaultCustomDays);
+    }
+
+    [Fact]
+    public void HandleSave_WithPausedRepeat_SetsIsPaused()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule { Type = RepeatType.Daily });
+        TaskItem? savedTask = null;
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters
+                .Add(p => p.Task, task)
+                .Add(p => p.OnSave, EventCallback.Factory.Create<TaskItem>(this, t => savedTask = t)));
+
+        cut.Find(".tep-toggle").Click();
+        cut.Find(".tep-save-btn").Click();
+
+        savedTask.Should().NotBeNull();
+        savedTask!.Repeat.Should().NotBeNull();
+        savedTask.Repeat!.IsPaused.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToggleWeekday_ClickAddsDay()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Weekly,
+            Weekdays = [DayOfWeek.Monday]
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        var buttons = cut.FindAll(".tep-weekday-btn");
+        var tuesdayBtn = buttons.First(b => b.TextContent.Contains("Tu"));
+        tuesdayBtn.Click();
+
+        cut.FindAll(".tep-weekday-btn.active").Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void ToggleWeekday_ClickRemovesDay()
+    {
+        var task = CreateTask(t => t.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Weekly,
+            Weekdays = [DayOfWeek.Monday]
+        });
+        var cut = RenderComponent<TaskEditPanel>(parameters =>
+            parameters.Add(p => p.Task, task));
+
+        var buttons = cut.FindAll(".tep-weekday-btn");
+        var mondayBtn = buttons.First(b => b.TextContent.Contains("Mo"));
+        mondayBtn.Click();
+
+        cut.FindAll(".tep-weekday-btn.active").Count.Should().Be(0);
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
@@ -591,5 +591,44 @@ public class TaskItemComponentTests : TestContext
         badge.GetAttribute("title").Should().Be("Daily");
         badge.ClassList.Should().NotContain("paused");
     }
+
+    [Fact]
+    public void TaskItemComponent_WithNullRepeat_DoesNotShowBadge()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Task",
+            TotalFocusMinutes = 25,
+            PomodoroCount = 2,
+            IsCompleted = false,
+            Repeat = null
+        };
+
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.FindAll(".task-badge").Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void TaskItemComponent_WithPausedRepeat_ShowsPausedBadge()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Task",
+            TotalFocusMinutes = 25,
+            PomodoroCount = 2,
+            IsCompleted = false,
+            Repeat = new RepeatRule { Type = RepeatType.Daily, IsPaused = true }
+        };
+
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        var badge = cut.Find(".task-badge");
+        badge.ClassList.Should().Contain("repeat-paused");
+    }
 }
 

--- a/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Pomodoro.Web.Components.Tasks;
@@ -568,6 +569,27 @@ public class TaskItemComponentTests : TestContext
         taskItem.KeyDown("Enter");
 
         Assert.False(selected);
+    }
+
+    [Fact]
+    public void TaskItemComponent_NonPausedRepeat_ShowsTooltipWithoutPaused()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Task",
+            TotalFocusMinutes = 25,
+            PomodoroCount = 2,
+            IsCompleted = false,
+            Repeat = new RepeatRule { Type = RepeatType.Daily }
+        };
+
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        var badge = cut.Find(".task-badge");
+        badge.GetAttribute("title").Should().Be("Daily");
+        badge.ClassList.Should().NotContain("paused");
     }
 }
 

--- a/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskItemComponentTests.cs
@@ -589,7 +589,7 @@ public class TaskItemComponentTests : TestContext
 
         var badge = cut.Find(".task-badge");
         badge.GetAttribute("title").Should().Be("Daily");
-        badge.ClassList.Should().NotContain("paused");
+        badge.ClassList.Should().NotContain("repeat-paused");
     }
 
     [Fact]

--- a/tests/Pomodoro.Web.Tests/Components/TaskItemEditTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskItemEditTests.cs
@@ -1,0 +1,210 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Pomodoro.Web.Components.Tasks;
+using Pomodoro.Web.Models;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Components;
+
+[Trait("Category", "Component")]
+public class TaskItemEditTests : TestContext
+{
+    [Fact]
+    public void HandleEdit_ShowsEditPanel()
+    {
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Test" };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find("button[aria-label=\"Edit task\"]").Click();
+
+        cut.Markup.Should().Contain("task-edit-panel");
+    }
+
+    [Fact]
+    public void HandleEditSave_InvokesOnEditAndClosesPanel()
+    {
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Test" };
+        TaskItem? editedTask = null;
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters
+                .Add(p => p.Item, task)
+                .Add(p => p.OnEdit, EventCallback.Factory.Create<TaskItem>(this, t => editedTask = t)));
+
+        cut.Find("button[aria-label=\"Edit task\"]").Click();
+        cut.Find(".tep-save-btn").Click();
+
+        editedTask.Should().NotBeNull();
+        editedTask!.Id.Should().Be(task.Id);
+        cut.Markup.Should().NotContain("task-edit-panel");
+    }
+
+    [Fact]
+    public void HandleEditCancel_ClosesPanelWithoutInvokingOnEdit()
+    {
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Test" };
+        var editFired = false;
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters
+                .Add(p => p.Item, task)
+                .Add(p => p.OnEdit, EventCallback.Factory.Create<TaskItem>(this, _ => editFired = true)));
+
+        cut.Find("button[aria-label=\"Edit task\"]").Click();
+        cut.Find(".tep-cancel-btn").Click();
+
+        editFired.Should().BeFalse();
+        cut.Markup.Should().NotContain("task-edit-panel");
+    }
+
+    [Fact]
+    public void Render_WithRecurringTask_ShowsRepeatBadge()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Recurring Task",
+            Repeat = new RepeatRule { Type = RepeatType.Daily }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Markup.Should().Contain("task-repeat");
+        cut.Markup.Should().Contain(Constants.Repeat.RepeatIcon);
+    }
+
+    [Fact]
+    public void Render_WithPausedRepeat_ShowsPausedClass()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Paused Task",
+            Repeat = new RepeatRule { Type = RepeatType.Daily, IsPaused = true }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Markup.Should().Contain("task-repeat");
+        cut.Markup.Should().Contain("repeat-paused");
+    }
+
+    [Fact]
+    public void GetRepeatTooltip_Daily()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Repeat = new RepeatRule { Type = RepeatType.Daily }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find(".task-repeat").GetAttribute("title").Should().Be("Daily");
+    }
+
+    [Fact]
+    public void GetRepeatTooltip_Weekly()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Repeat = new RepeatRule { Type = RepeatType.Weekly }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find(".task-repeat").GetAttribute("title").Should().Be("Weekly");
+    }
+
+    [Fact]
+    public void GetRepeatTooltip_Custom()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Repeat = new RepeatRule { Type = RepeatType.Custom, CustomDays = 5 }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find(".task-repeat").GetAttribute("title").Should().Be("Every 5 days");
+    }
+
+    [Fact]
+    public void GetRepeatTooltip_Monthly()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Repeat = new RepeatRule { Type = RepeatType.Monthly, MonthlyDay = 15 }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find(".task-repeat").GetAttribute("title").Should().Be("Monthly (day 15)");
+    }
+
+    [Fact]
+    public void GetRepeatTooltip_PausedSuffix()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            Repeat = new RepeatRule { Type = RepeatType.Daily, IsPaused = true }
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Find(".task-repeat").GetAttribute("title").Should().Be("Daily (paused)");
+    }
+
+    [Fact]
+    public void Render_WithScheduledDate_ShowsScheduleBadge()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Scheduled Task",
+            ScheduledDate = new DateTime(2026, 6, 15)
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Markup.Should().Contain("task-scheduled");
+        cut.Markup.Should().Contain(Constants.Repeat.ScheduleIcon);
+    }
+
+    [Fact]
+    public void Render_WithRecurringAndScheduled_ShowsBothBadges()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Both Task",
+            Repeat = new RepeatRule { Type = RepeatType.Daily },
+            ScheduledDate = new DateTime(2026, 6, 15)
+        };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Markup.Should().Contain("task-repeat");
+        cut.Markup.Should().Contain("task-scheduled");
+    }
+
+    [Fact]
+    public void Render_WithoutRepeatOrSchedule_ShowsNoBadges()
+    {
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Plain Task" };
+        var cut = RenderComponent<TaskItemComponent>(parameters =>
+            parameters.Add(p => p.Item, task));
+
+        cut.Markup.Should().NotContain("task-repeat");
+        cut.Markup.Should().NotContain("task-scheduled");
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Components/TaskListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskListTests.cs
@@ -446,6 +446,28 @@ public class TaskListTests : TestContext
         Assert.Equal(taskId, uncompletedTaskId);
     }
 
+    [Fact]
+    public void TaskList_EditButton_TriggersOnTaskEditCallback()
+    {
+        TaskItem? editedTask = null;
+        var taskId = Guid.NewGuid();
+        var tasks = new List<TaskItem>
+        {
+            new() { Id = taskId, Name = "Active Task", IsCompleted = false }
+        };
+
+        var cut = RenderComponent<TaskList>(parameters => parameters
+            .Add(p => p.Tasks, tasks)
+            .Add(p => p.CurrentTaskId, null)
+            .Add(p => p.OnTaskEdit, EventCallback.Factory.Create<TaskItem>(this, t => editedTask = t)));
+
+        cut.Find("button[aria-label=\"Edit task\"]").Click();
+        cut.Find(".tep-save-btn").Click();
+
+        Assert.NotNull(editedTask);
+        Assert.Equal(taskId, editedTask!.Id);
+    }
+
     #endregion
 
     #region Task Item Header Tests

--- a/tests/Pomodoro.Web.Tests/Components/TimerDisplayCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TimerDisplayCoverageTests.cs
@@ -125,6 +125,22 @@ public class TimerDisplayCoverageTests : TestContext
         Assert.True(errorEvent.Wait(3000), "Logger.LogError should have been called from catch block");
     }
 
+    [Fact]
+    public void CurrentIsRunning_ReflectsTimerServiceState()
+    {
+        SetupTimerService(TimeSpan.FromMinutes(25), SessionType.Pomodoro, true);
+        var testable = new TestableTimerDisplay(
+            _timerServiceMock.Object, _mockLogger.Object);
+
+        Assert.True(testable.IsRunning);
+
+        SetupTimerService(TimeSpan.FromMinutes(25), SessionType.Pomodoro, false);
+        var testable2 = new TestableTimerDisplay(
+            _timerServiceMock.Object, _mockLogger.Object);
+
+        Assert.False(testable2.IsRunning);
+    }
+
     private class TestableTimerDisplay : TimerDisplayBase
     {
         public TestableTimerDisplay(ITimerService timerService, ILogger<TimerDisplayBase> logger)
@@ -132,6 +148,8 @@ public class TimerDisplayCoverageTests : TestContext
             TimerService = timerService;
             Logger = logger;
         }
+
+        public bool IsRunning => CurrentIsRunning;
     }
 }
 

--- a/tests/Pomodoro.Web.Tests/Models/TaskItemTests/TaskItemTests.Repeat.cs
+++ b/tests/Pomodoro.Web.Tests/Models/TaskItemTests/TaskItemTests.Repeat.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Pomodoro.Web.Models;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Models;
+
+[Trait("Category", "Model")]
+public class TaskItemRepeatTests
+{
+    [Fact]
+    public void RepeatRule_IsActive_True_WhenNotPausedAndNotNone()
+    {
+        var rule = new RepeatRule { Type = RepeatType.Daily, IsPaused = false };
+        rule.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RepeatRule_IsActive_False_WhenPaused()
+    {
+        var rule = new RepeatRule { Type = RepeatType.Daily, IsPaused = true };
+        rule.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RepeatRule_IsActive_False_WhenNone()
+    {
+        var rule = new RepeatRule { Type = RepeatType.None, IsPaused = false };
+        rule.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RepeatRule_IsActive_False_WhenNoneAndPaused()
+    {
+        var rule = new RepeatRule { Type = RepeatType.None, IsPaused = true };
+        rule.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsRecurring_True_WhenRepeatTypeIsNotNone()
+    {
+        var task = new TaskItem { Repeat = new RepeatRule { Type = RepeatType.Daily } };
+        task.IsRecurring.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TaskItem_IsRecurring_False_WhenRepeatIsNull()
+    {
+        var task = new TaskItem { Repeat = null };
+        task.IsRecurring.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsRecurring_False_WhenRepeatTypeIsNone()
+    {
+        var task = new TaskItem { Repeat = new RepeatRule { Type = RepeatType.None } };
+        task.IsRecurring.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsScheduled_True_WhenScheduledDateSet()
+    {
+        var task = new TaskItem { ScheduledDate = DateTime.UtcNow.Date };
+        task.IsScheduled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TaskItem_IsScheduled_False_WhenScheduledDateNull()
+    {
+        var task = new TaskItem { ScheduledDate = null };
+        task.IsScheduled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsVisible_True_WhenNotDeleted()
+    {
+        var task = new TaskItem { IsDeleted = false };
+        task.IsVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TaskItem_IsVisible_False_WhenDeleted()
+    {
+        var task = new TaskItem { IsDeleted = true };
+        task.IsVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsVisible_False_WhenScheduledForFuture()
+    {
+        var task = new TaskItem { ScheduledDate = DateTime.UtcNow.Date.AddDays(1) };
+        task.IsVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TaskItem_IsVisible_True_WhenScheduledForPast()
+    {
+        var task = new TaskItem { ScheduledDate = DateTime.UtcNow.Date.AddDays(-1) };
+        task.IsVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TaskItem_IsVisible_True_WhenScheduledForToday()
+    {
+        var task = new TaskItem { ScheduledDate = DateTime.UtcNow.Date };
+        task.IsVisible.Should().BeTrue();
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Models/TaskItemTests/TaskItemTests.Repeat.cs
+++ b/tests/Pomodoro.Web.Tests/Models/TaskItemTests/TaskItemTests.Repeat.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Pomodoro.Web.Tests.Models;
 
-[Trait("Category", "Model")]
+[Trait("Category", "Service")]
 public class TaskItemRepeatTests
 {
     [Fact]

--- a/tests/Pomodoro.Web.Tests/Pages/HistoryCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/HistoryCoverageTests.cs
@@ -1,0 +1,94 @@
+using Bunit;
+using FluentAssertions;
+using Moq;
+using Pomodoro.Web.Models;
+using Pomodoro.Web.Pages;
+using Pomodoro.Web.Services;
+using System.Reflection;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Pages;
+
+[Trait("Category", "Page")]
+public class HistoryCoverageTests : TestHelper
+{
+    public HistoryCoverageTests()
+    {
+        ActivityServiceMock.Setup(x => x.GetActivitiesPagedAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivitiesForDate(It.IsAny<DateTime>()))
+            .Returns(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivityCountAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(0);
+        ActivityServiceMock.Setup(x => x.GetDailyFocusMinutes(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        ActivityServiceMock.Setup(x => x.GetDailyBreakMinutes(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        StatisticsServiceMock.Setup(x => x.GetWeeklyStatsAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new WeeklyStats());
+        ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        InfiniteScrollInteropMock.Setup(x => x.IsSupportedAsync()).ReturnsAsync(false);
+    }
+
+    [Fact]
+    public void UpdateFormattedDate_OtherDate_ShowsOnlyDate()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialSelectedDate, new DateTime(2023, 1, 5)));
+
+        var method = typeof(HistoryBase).GetMethod("UpdateFormattedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        method!.Invoke(cut.Instance, null);
+
+        var formattedProp = typeof(HistoryBase).GetProperty("FormattedSelectedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        var todayProp = typeof(HistoryBase).GetProperty("IsSelectedDateToday", BindingFlags.Instance | BindingFlags.NonPublic);
+        formattedProp!.GetValue(cut.Instance).Should().Be("Jan 5");
+        todayProp!.GetValue(cut.Instance).Should().Be(false);
+    }
+
+    [Fact]
+    public void UpdateFormattedDate_Today_ShowsTodayPrefix()
+    {
+        var today = DateTime.Now.Date;
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialSelectedDate, today));
+
+        var method = typeof(HistoryBase).GetMethod("UpdateFormattedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        method!.Invoke(cut.Instance, null);
+
+        var formattedProp = typeof(HistoryBase).GetProperty("FormattedSelectedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        var todayProp = typeof(HistoryBase).GetProperty("IsSelectedDateToday", BindingFlags.Instance | BindingFlags.NonPublic);
+        formattedProp!.GetValue(cut.Instance).Should().Be($"Today, {today:MMM d}");
+        todayProp!.GetValue(cut.Instance).Should().Be(true);
+    }
+
+    [Fact]
+    public void UpdateFormattedDate_Yesterday_ShowsYesterdayPrefix()
+    {
+        var yesterday = DateTime.Now.Date.AddDays(-1);
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialSelectedDate, yesterday));
+
+        var method = typeof(HistoryBase).GetMethod("UpdateFormattedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        method!.Invoke(cut.Instance, null);
+
+        var formattedProp = typeof(HistoryBase).GetProperty("FormattedSelectedDate", BindingFlags.Instance | BindingFlags.NonPublic);
+        formattedProp!.GetValue(cut.Instance).Should().Be($"Yesterday, {yesterday:MMM d}");
+    }
+
+    [Fact]
+    public async Task HandleWeekChanged_UpdatesWeekStart()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialSelectedWeekStart, new DateTime(2023, 1, 2)));
+
+        await cut.InvokeAsync(() =>
+        {
+            var method = typeof(HistoryBase).GetMethod("HandleWeekChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+            return (Task)method!.Invoke(cut.Instance, [new DateTime(2023, 2, 6)])!;
+        });
+
+        var prop = typeof(HistoryBase).GetProperty("SelectedWeekStart", BindingFlags.Instance | BindingFlags.NonPublic);
+        prop!.GetValue(cut.Instance).Should().Be(new DateTime(2023, 2, 6));
+    }
+
+}

--- a/tests/Pomodoro.Web.Tests/Pages/HistoryCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/HistoryCoverageTests.cs
@@ -41,7 +41,7 @@ public class HistoryCoverageTests : TestHelper
 
         var formattedProp = typeof(HistoryBase).GetProperty("FormattedSelectedDate", BindingFlags.Instance | BindingFlags.NonPublic);
         var todayProp = typeof(HistoryBase).GetProperty("IsSelectedDateToday", BindingFlags.Instance | BindingFlags.NonPublic);
-        formattedProp!.GetValue(cut.Instance).Should().Be("Jan 5");
+        formattedProp!.GetValue(cut.Instance).Should().Be(new DateTime(2023, 1, 5).ToString("MMM d"));
         todayProp!.GetValue(cut.Instance).Should().Be(false);
     }
 

--- a/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
@@ -1,0 +1,371 @@
+using Bunit;
+using FluentAssertions;
+using Moq;
+using Pomodoro.Web.Models;
+using Pomodoro.Web.Pages;
+using Pomodoro.Web.Services;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Pages;
+
+[Trait("Category", "Page")]
+public class IndexCoverageTests : TestHelper
+{
+    public IndexCoverageTests()
+    {
+        NotificationServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        PipTimerServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TaskServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TaskServiceMock.SetupGet(x => x.Tasks).Returns(new List<TaskItem>());
+        TaskServiceMock.SetupGet(x => x.AllTasks).Returns(new List<TaskItem>());
+        TaskServiceMock.SetupGet(x => x.CurrentTaskId).Returns((Guid?)null);
+        TaskServiceMock.SetupGet(x => x.CurrentTask).Returns((TaskItem?)null);
+        TimerServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TimerServiceMock.SetupGet(x => x.RemainingTime).Returns(TimeSpan.FromMinutes(25));
+        TimerServiceMock.SetupGet(x => x.CurrentSessionType).Returns(SessionType.Pomodoro);
+        TimerServiceMock.SetupGet(x => x.IsRunning).Returns(false);
+        TimerServiceMock.SetupGet(x => x.IsPaused).Returns(false);
+        TimerServiceMock.SetupGet(x => x.IsStarted).Returns(false);
+        TimerServiceMock.SetupGet(x => x.Settings).Returns(new TimerSettings());
+        ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TodayStatsServiceMock.Setup(x => x.GetTodayStats()).Returns((120, 4, 2));
+        KeyboardShortcutServiceMock.Setup(x => x.RegisterShortcut(It.IsAny<string>(), It.IsAny<Action>(), It.IsAny<string>()));
+        JSRuntimeMock.Setup(x => x.InvokeAsync<string?>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync((string?)null);
+    }
+
+    [Fact]
+    public async Task HandleTaskEdit_CallsUpdateTaskAsync()
+    {
+        TaskServiceMock.Setup(x => x.UpdateTaskAsync(It.IsAny<TaskItem>())).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Updated" };
+
+        await cut.Instance.HandleTaskEdit(task);
+
+        TaskServiceMock.Verify(x => x.UpdateTaskAsync(task), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTaskEdit_OnException_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.UpdateTaskAsync(It.IsAny<TaskItem>())).ThrowsAsync(new Exception("update failed"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var task = new TaskItem { Id = Guid.NewGuid(), Name = "Updated" };
+
+        await cut.Instance.HandleTaskEdit(task);
+
+        cut.Instance.ErrorMessage.Should().Contain("update failed");
+    }
+
+    [Fact]
+    public async Task HandleConsentOptionSelect_IsResume_CallsResumeInterrupted()
+    {
+        TimerServiceMock.Setup(x => x.ResumeInterruptedPomodoroAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var option = new ConsentOption { IsResume = true, SessionType = SessionType.Pomodoro };
+
+        await cut.Instance.HandleConsentOptionSelect(option);
+
+        TimerServiceMock.Verify(x => x.ResumeInterruptedPomodoroAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleConsentOptionSelect_NotResume_CallsSelectOptionAsync()
+    {
+        ConsentServiceMock.Setup(x => x.SelectOptionAsync(It.IsAny<SessionType>())).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var option = new ConsentOption { IsResume = false, SessionType = SessionType.ShortBreak };
+
+        await cut.Instance.HandleConsentOptionSelect(option);
+
+        ConsentServiceMock.Verify(x => x.SelectOptionAsync(SessionType.ShortBreak), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleConsentOptionSelect_OnException_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.ResumeInterruptedPomodoroAsync()).ThrowsAsync(new Exception("resume failed"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var option = new ConsentOption { IsResume = true, SessionType = SessionType.Pomodoro };
+
+        await cut.Instance.HandleConsentOptionSelect(option);
+
+        cut.Instance.ErrorMessage.Should().Contain("resume failed");
+    }
+
+    [Fact]
+    public async Task OnTimerCompleted_UpdatesStateSuccessfully()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var args = new TimerCompletedEventArgs(SessionType.Pomodoro, Guid.NewGuid(), "Task", 25, true, DateTime.UtcNow);
+
+        await cut.Instance.OnTimerCompleted(args);
+
+        cut.Instance.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SafeAsyncInternal_Exception_LogsError()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.SafeAsyncInternal(() => throw new Exception("safe error"), "TestHandler");
+
+        cut.Instance.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckPendingNotificationActionAsync_Exception_LogsError()
+    {
+        JSRuntimeMock.Setup(x => x.InvokeAsync<string>(It.IsAny<string>(), It.IsAny<object[]>()))
+            .ThrowsAsync(new Exception("js error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.CheckPendingNotificationActionAsync();
+
+        cut.Instance.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void TodayStats_CacheBehavior()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        var prop = typeof(IndexBase).GetProperty("TodayTotalFocusMinutes", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var focus1 = (int)prop!.GetValue(cut.Instance)!;
+        var focus2 = (int)prop.GetValue(cut.Instance)!;
+
+        focus1.Should().Be(120);
+        focus2.Should().Be(120);
+        TodayStatsServiceMock.Verify(x => x.GetTodayStats(), Times.Once);
+    }
+
+    [Fact]
+    public void OnActivityChanged_InvalidatesCache()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        var prop = typeof(IndexBase).GetProperty("TodayTotalFocusMinutes", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var focus1 = (int)prop!.GetValue(cut.Instance)!;
+        ActivityServiceMock.Raise(x => x.OnActivityChanged += null);
+        var focus2 = (int)prop.GetValue(cut.Instance)!;
+
+        TodayStatsServiceMock.Verify(x => x.GetTodayStats(), Times.AtLeast(2));
+    }
+
+    [Fact]
+    public async Task HandleTimerStart_PomodoroWithoutTask_SetsError()
+    {
+        TaskServiceMock.SetupGet(x => x.CurrentTaskId).Returns((Guid?)null);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerStart());
+
+        cut.Instance.ErrorMessage.Should().Contain("select a task");
+    }
+
+    [Fact]
+    public async Task HandleTimerStart_PomodoroWithTask_StartsPomodoro()
+    {
+        var taskId = Guid.NewGuid();
+        TaskServiceMock.SetupGet(x => x.CurrentTaskId).Returns(taskId);
+        TimerServiceMock.Setup(x => x.StartPomodoroAsync(taskId)).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTimerStart();
+
+        TimerServiceMock.Verify(x => x.StartPomodoroAsync(taskId), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTimerStart_ShortBreak_StartsShortBreak()
+    {
+        TimerServiceMock.Setup(x => x.StartShortBreakAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        cut.Instance.CurrentSessionType = SessionType.ShortBreak;
+
+        await cut.Instance.HandleTimerStart();
+
+        TimerServiceMock.Verify(x => x.StartShortBreakAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTimerStart_LongBreak_StartsLongBreak()
+    {
+        TimerServiceMock.Setup(x => x.StartLongBreakAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        cut.Instance.CurrentSessionType = SessionType.LongBreak;
+
+        await cut.Instance.HandleTimerStart();
+
+        TimerServiceMock.Verify(x => x.StartLongBreakAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTimerStart_Exception_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.StartShortBreakAsync()).ThrowsAsync(new Exception("start error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        cut.Instance.CurrentSessionType = SessionType.ShortBreak;
+
+        await cut.Instance.HandleTimerStart();
+
+        cut.Instance.ErrorMessage.Should().Contain("start error");
+    }
+
+    [Fact]
+    public async Task HandleTimerPause_Exception_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.PauseAsync()).ThrowsAsync(new Exception("pause error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTimerPause();
+
+        cut.Instance.ErrorMessage.Should().Contain("pause error");
+    }
+
+    [Fact]
+    public async Task HandleTimerPause_Success_UpdatesState()
+    {
+        TimerServiceMock.Setup(x => x.PauseAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerPause());
+
+        TimerServiceMock.Verify(x => x.PauseAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTimerResume_Exception_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.ResumeAsync()).ThrowsAsync(new Exception("resume error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTimerResume();
+
+        cut.Instance.ErrorMessage.Should().Contain("resume error");
+    }
+
+    [Fact]
+    public async Task HandleTimerResume_Success_UpdatesState()
+    {
+        TimerServiceMock.Setup(x => x.ResumeAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerResume());
+
+        TimerServiceMock.Verify(x => x.ResumeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleTimerReset_Exception_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.ResetAsync()).ThrowsAsync(new Exception("reset error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTimerReset();
+
+        cut.Instance.ErrorMessage.Should().Contain("reset error");
+    }
+
+    [Fact]
+    public async Task HandleTimerReset_Success_UpdatesState()
+    {
+        TimerServiceMock.Setup(x => x.ResetAsync()).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerReset());
+
+        TimerServiceMock.Verify(x => x.ResetAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleSessionSwitch_Exception_SetsErrorMessage()
+    {
+        TimerServiceMock.Setup(x => x.SwitchSessionTypeAsync(It.IsAny<SessionType>())).ThrowsAsync(new Exception("switch error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleSessionSwitch(SessionType.ShortBreak);
+
+        cut.Instance.ErrorMessage.Should().Contain("switch error");
+    }
+
+    [Fact]
+    public async Task HandleTogglePip_OpenFails_SetsError()
+    {
+        PipTimerServiceMock.Setup(x => x.IsOpen).Returns(false);
+        PipTimerServiceMock.Setup(x => x.OpenAsync()).ReturnsAsync(false);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.InvokeAsync(() => cut.Instance.HandleTogglePip());
+
+        cut.Instance.ErrorMessage.Should().Contain("Pop-up");
+    }
+
+    [Fact]
+    public async Task HandleTogglePip_Exception_SetsErrorMessage()
+    {
+        PipTimerServiceMock.Setup(x => x.IsOpen).Returns(false);
+        PipTimerServiceMock.Setup(x => x.OpenAsync()).ThrowsAsync(new Exception("pip error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTogglePip();
+
+        cut.Instance.ErrorMessage.Should().Contain("pip error");
+    }
+
+    [Fact]
+    public async Task HandleTaskAdd_Exception_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.AddTaskAsync(It.IsAny<string>())).ThrowsAsync(new Exception("add error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTaskAdd("Test");
+
+        cut.Instance.ErrorMessage.Should().Contain("add error");
+    }
+
+    [Fact]
+    public async Task HandleTaskSelect_Exception_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.SelectTaskAsync(It.IsAny<Guid>())).ThrowsAsync(new Exception("select error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTaskSelect(Guid.NewGuid());
+
+        cut.Instance.ErrorMessage.Should().Contain("select error");
+    }
+
+    [Fact]
+    public async Task HandleTaskComplete_Exception_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.CompleteTaskAsync(It.IsAny<Guid>())).ThrowsAsync(new Exception("complete error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTaskComplete(Guid.NewGuid());
+
+        cut.Instance.ErrorMessage.Should().Contain("complete error");
+    }
+
+    [Fact]
+    public async Task HandleTaskDelete_Exception_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.DeleteTaskAsync(It.IsAny<Guid>())).ThrowsAsync(new Exception("delete error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTaskDelete(Guid.NewGuid());
+
+        cut.Instance.ErrorMessage.Should().Contain("delete error");
+    }
+
+    [Fact]
+    public async Task HandleTaskUncomplete_Exception_SetsErrorMessage()
+    {
+        TaskServiceMock.Setup(x => x.UncompleteTaskAsync(It.IsAny<Guid>())).ThrowsAsync(new Exception("uncomplete error"));
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        await cut.Instance.HandleTaskUncomplete(Guid.NewGuid());
+
+        cut.Instance.ErrorMessage.Should().Contain("uncomplete error");
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
@@ -383,3 +383,118 @@ file sealed class ThrowingTestIndexJsRuntime : IJSRuntime
     public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) => throw new Exception("js error");
     public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) => throw new Exception("js error");
 }
+
+[Trait("Category", "Page")]
+public class IndexPageRenderingTests : TestHelper
+{
+    public IndexPageRenderingTests()
+    {
+        NotificationServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        PipTimerServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TaskServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TaskServiceMock.SetupGet(x => x.Tasks).Returns(new List<TaskItem>());
+        TaskServiceMock.SetupGet(x => x.AllTasks).Returns(new List<TaskItem>());
+        TaskServiceMock.SetupGet(x => x.CurrentTaskId).Returns((Guid?)null);
+        TaskServiceMock.SetupGet(x => x.CurrentTask).Returns((TaskItem?)null);
+        TimerServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TimerServiceMock.SetupGet(x => x.RemainingTime).Returns(TimeSpan.FromMinutes(25));
+        TimerServiceMock.SetupGet(x => x.CurrentSessionType).Returns(SessionType.Pomodoro);
+        TimerServiceMock.SetupGet(x => x.IsRunning).Returns(false);
+        TimerServiceMock.SetupGet(x => x.IsPaused).Returns(false);
+        TimerServiceMock.SetupGet(x => x.IsStarted).Returns(false);
+        TimerServiceMock.SetupGet(x => x.Settings).Returns(new TimerSettings());
+        ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        TodayStatsServiceMock.Setup(x => x.GetTodayStats()).Returns((120, 4, 2));
+        KeyboardShortcutServiceMock.Setup(x => x.RegisterShortcut(It.IsAny<string>(), It.IsAny<Action>(), It.IsAny<string>()));
+    }
+
+    [Fact]
+    public void IndexPage_LoadingState_ShowsSpinner()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        var loadingProp = typeof(IndexBase).GetProperty("IsLoading", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        loadingProp!.SetValue(cut.Instance, true);
+        cut.Render();
+
+        cut.Markup.Should().Contain("loading-container");
+        cut.Markup.Should().Contain("Loading...");
+    }
+
+    [Fact]
+    public void IndexPage_ClickShortBreakTab_SwitchesSession()
+    {
+        TimerServiceMock.Setup(x => x.SwitchSessionTypeAsync(SessionType.ShortBreak)).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        cut.Find("button[title='S']").Click();
+
+        TimerServiceMock.Verify(x => x.SwitchSessionTypeAsync(SessionType.ShortBreak), Times.Once);
+    }
+
+    [Fact]
+    public void IndexPage_ClickLongBreakTab_SwitchesSession()
+    {
+        TimerServiceMock.Setup(x => x.SwitchSessionTypeAsync(SessionType.LongBreak)).Returns(Task.CompletedTask);
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        cut.Find("button[title='L']").Click();
+
+        TimerServiceMock.Verify(x => x.SwitchSessionTypeAsync(SessionType.LongBreak), Times.Once);
+    }
+
+    [Fact]
+    public void IndexPage_ClickKeyboardHelp_ShowsModal()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        cut.Find("button[aria-label='Keyboard shortcuts']").Click();
+
+        cut.Instance.ShowKeyboardHelp.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IndexPage_CloseKeyboardHelp_HidesModal()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+        cut.Instance.ShowKeyboardHelp = true;
+        cut.Render();
+
+        cut.Find("button.modal-close").Click();
+
+        cut.Instance.ShowKeyboardHelp.Should().BeFalse();
+    }
+}
+
+[Trait("Category", "Page")]
+public class HistoryPageRenderingTests : TestHelper
+{
+    public HistoryPageRenderingTests()
+    {
+        ActivityServiceMock.Setup(x => x.GetActivitiesPagedAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivitiesForDate(It.IsAny<DateTime>()))
+            .Returns(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivityCountAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(0);
+        ActivityServiceMock.Setup(x => x.GetDailyFocusMinutes(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        ActivityServiceMock.Setup(x => x.GetDailyBreakMinutes(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        StatisticsServiceMock.Setup(x => x.GetWeeklyStatsAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new WeeklyStats());
+        ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        InfiniteScrollInteropMock.Setup(x => x.IsSupportedAsync()).ReturnsAsync(false);
+    }
+
+    [Fact]
+    public void HistoryPage_LoadingState_ShowsSpinner()
+    {
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>();
+        var loadingProp = typeof(HistoryBase).GetProperty("IsLoading", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        loadingProp!.SetValue(cut.Instance, true);
+        cut.Render();
+
+        cut.Markup.Should().Contain("loading-container");
+        cut.Markup.Should().Contain("Loading history...");
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
@@ -1,5 +1,7 @@
 using Bunit;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 using Moq;
 using Pomodoro.Web.Models;
 using Pomodoro.Web.Pages;
@@ -30,7 +32,6 @@ public class IndexCoverageTests : TestHelper
         ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
         TodayStatsServiceMock.Setup(x => x.GetTodayStats()).Returns((120, 4, 2));
         KeyboardShortcutServiceMock.Setup(x => x.RegisterShortcut(It.IsAny<string>(), It.IsAny<Action>(), It.IsAny<string>()));
-        JSRuntimeMock.Setup(x => x.InvokeAsync<string?>(It.IsAny<string>(), It.IsAny<object[]>())).ReturnsAsync((string?)null);
     }
 
     [Fact]
@@ -117,8 +118,7 @@ public class IndexCoverageTests : TestHelper
     [Fact]
     public async Task CheckPendingNotificationActionAsync_Exception_LogsError()
     {
-        JSRuntimeMock.Setup(x => x.InvokeAsync<string>(It.IsAny<string>(), It.IsAny<object[]>()))
-            .ThrowsAsync(new Exception("js error"));
+        Services.AddSingleton<IJSRuntime>(new ThrowingTestIndexJsRuntime());
         var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
 
         await cut.Instance.CheckPendingNotificationActionAsync();
@@ -368,4 +368,18 @@ public class IndexCoverageTests : TestHelper
 
         cut.Instance.ErrorMessage.Should().Contain("uncomplete error");
     }
+}
+
+file sealed class TestIndexJsRuntime : IJSRuntime
+{
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken = default) => default;
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) => default;
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) => default;
+}
+
+file sealed class ThrowingTestIndexJsRuntime : IJSRuntime
+{
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken = default) => throw new Exception("js error");
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) => throw new Exception("js error");
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) => throw new Exception("js error");
 }

--- a/tests/Pomodoro.Web.Tests/Services/ConsentServiceTests/ConsentServiceTests.Coverage.cs
+++ b/tests/Pomodoro.Web.Tests/Services/ConsentServiceTests/ConsentServiceTests.Coverage.cs
@@ -364,5 +364,43 @@ public partial class ConsentServiceTests
     }
 
     #endregion
+
+    #region RefreshOptions - modal not visible (line 182)
+
+    [Fact]
+    public void RefreshOptions_WhenModalNotVisible_DoesNotUpdateOptionsOrFireEvent()
+    {
+        var timerServiceMock = new Mock<ITimerService>();
+        var taskServiceMock = new Mock<ITaskService>();
+        var notificationServiceMock = new Mock<INotificationService>();
+        var sessionOptionsServiceMock = new Mock<ISessionOptionsService>();
+        var loggerMock = new Mock<ILogger<ConsentService>>();
+        var appState = new AppState
+        {
+            Settings = new TimerSettings
+            {
+                AutoStartSession = false,
+                SoundEnabled = false,
+                NotificationsEnabled = false
+            }
+        };
+
+        var service = new ConsentService(
+            timerServiceMock.Object, taskServiceMock.Object,
+            notificationServiceMock.Object, appState,
+            sessionOptionsServiceMock.Object, loggerMock.Object);
+
+        var eventFired = false;
+        service.OnConsentRequired += () => eventFired = true;
+
+        service.RefreshOptions();
+
+        Assert.False(eventFired);
+        sessionOptionsServiceMock.Verify(
+            x => x.GetOptionsForSessionType(It.IsAny<SessionType>(), It.IsAny<TimerSession>()),
+            Times.Never);
+    }
+
+    #endregion
 }
 

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Initialize.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Initialize.cs
@@ -135,6 +135,41 @@ public partial class TaskServiceTests
         Assert.True(eventFired);
     }
 
+    [Fact]
+    public async Task InitializeAsync_WithDueRecurringTask_ActivatesTask()
+    {
+        var task = CreateSampleTask();
+        task.IsCompleted = true;
+        task.Repeat = new RepeatRule { Type = RepeatType.Daily, IsPaused = false, LastCompletedDate = DateTime.UtcNow.Date.AddDays(-1) };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        Assert.False(task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithRecurringTaskNullLastCompleted_ComputesNextOccurrence()
+    {
+        var task = CreateSampleTask();
+        task.IsCompleted = true;
+        task.Repeat = new RepeatRule { Type = RepeatType.Daily, IsPaused = false, LastCompletedDate = null };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+
+        Assert.True(task.IsCompleted);
+        Assert.NotNull(task.Repeat.NextOccurrence);
+    }
+
     #endregion
 }
 

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
@@ -134,13 +134,14 @@ public partial class TaskServiceTests
     [Fact]
     public async Task CompleteTaskAsync_RecurringNextAfterEnd_DoesNotSetNextOccurrence()
     {
+        var today = DateTime.UtcNow.Date;
         var taskId = Guid.NewGuid();
         var task = CreateSampleTask(id: taskId, isCompleted: false);
         task.Repeat = new RepeatRule
         {
             Type = RepeatType.Daily,
-            EndDate = DateTime.UtcNow.Date,
-            LastCompletedDate = DateTime.UtcNow.Date
+            EndDate = today,
+            LastCompletedDate = today
         };
 
         MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
@@ -294,6 +295,7 @@ public partial class TaskServiceTests
     [Fact]
     public async Task CompleteTaskAsync_RecurringCustomZeroDays_UsesDefault()
     {
+        var today = DateTime.UtcNow.Date;
         var taskId = Guid.NewGuid();
         var task = CreateSampleTask(id: taskId, isCompleted: false);
         task.Repeat = new RepeatRule { Type = RepeatType.Custom, CustomDays = 0 };
@@ -308,12 +310,13 @@ public partial class TaskServiceTests
         await service.CompleteTaskAsync(taskId);
 
         var next = service.AllTasks[0].Repeat.NextOccurrence!.Value;
-        Assert.Equal(DateTime.UtcNow.Date.AddDays(Constants.Repeat.DefaultCustomDays), next.Date);
+        Assert.Equal(today.AddDays(Constants.Repeat.DefaultCustomDays), next.Date);
     }
 
     [Fact]
     public async Task CompleteTaskAsync_RecurringWeeklyEmptyWeekdays_UsesFallback()
     {
+        var today = DateTime.UtcNow.Date;
         var taskId = Guid.NewGuid();
         var task = CreateSampleTask(id: taskId, isCompleted: false);
         task.Repeat = new RepeatRule { Type = RepeatType.Weekly, Weekdays = [] };
@@ -328,6 +331,6 @@ public partial class TaskServiceTests
         await service.CompleteTaskAsync(taskId);
 
         var next = service.AllTasks[0].Repeat.NextOccurrence!.Value;
-        Assert.Equal(DateTime.UtcNow.Date.AddDays(7), next.Date);
+        Assert.Equal(today.AddDays(7), next.Date);
     }
 }

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
@@ -132,6 +132,31 @@ public partial class TaskServiceTests
     }
 
     [Fact]
+    public async Task CompleteTaskAsync_RecurringNextAfterEnd_DoesNotSetNextOccurrence()
+    {
+        var taskId = Guid.NewGuid();
+        var task = CreateSampleTask(id: taskId, isCompleted: false);
+        task.Repeat = new RepeatRule
+        {
+            Type = RepeatType.Daily,
+            EndDate = DateTime.UtcNow.Date,
+            LastCompletedDate = DateTime.UtcNow.Date
+        };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockTaskRepository.Setup(r => r.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.CompleteTaskAsync(taskId);
+
+        Assert.True(service.AllTasks[0].IsCompleted);
+        Assert.Null(service.AllTasks[0].Repeat.NextOccurrence);
+    }
+
+    [Fact]
     public async Task CompleteTaskAsync_NonRecurring_CompletesNormally()
     {
         var taskId = Guid.NewGuid();

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceTests/TaskServiceTests.Repeat.cs
@@ -270,4 +270,64 @@ public partial class TaskServiceTests
 
         Assert.True(service.AllTasks[0].IsCompleted);
     }
+
+    [Fact]
+    public async Task CompleteTaskAsync_RecurringNoneType_DoesNotSetNextOccurrence()
+    {
+        var taskId = Guid.NewGuid();
+        var task = CreateSampleTask(id: taskId, isCompleted: false);
+        task.Repeat = new RepeatRule { Type = RepeatType.None };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockTaskRepository.Setup(r => r.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.CompleteTaskAsync(taskId);
+
+        Assert.True(service.AllTasks[0].IsCompleted);
+        Assert.Null(service.AllTasks[0].Repeat.NextOccurrence);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_RecurringCustomZeroDays_UsesDefault()
+    {
+        var taskId = Guid.NewGuid();
+        var task = CreateSampleTask(id: taskId, isCompleted: false);
+        task.Repeat = new RepeatRule { Type = RepeatType.Custom, CustomDays = 0 };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockTaskRepository.Setup(r => r.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.CompleteTaskAsync(taskId);
+
+        var next = service.AllTasks[0].Repeat.NextOccurrence!.Value;
+        Assert.Equal(DateTime.UtcNow.Date.AddDays(Constants.Repeat.DefaultCustomDays), next.Date);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_RecurringWeeklyEmptyWeekdays_UsesFallback()
+    {
+        var taskId = Guid.NewGuid();
+        var task = CreateSampleTask(id: taskId, isCompleted: false);
+        task.Repeat = new RepeatRule { Type = RepeatType.Weekly, Weekdays = [] };
+
+        MockTaskRepository.Setup(r => r.GetAllIncludingDeletedAsync()).ReturnsAsync(new List<TaskItem> { task });
+        MockTaskRepository.Setup(r => r.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        MockIndexedDb.Setup(d => d.GetAsync<AppStateRecord>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((AppStateRecord?)null);
+
+        var service = CreateService();
+        await service.InitializeAsync();
+        await service.CompleteTaskAsync(taskId);
+
+        var next = service.AllTasks[0].Repeat.NextOccurrence!.Value;
+        Assert.Equal(DateTime.UtcNow.Date.AddDays(7), next.Date);
+    }
 }

--- a/tests/e2e/fixtures/pomodoro.page.ts
+++ b/tests/e2e/fixtures/pomodoro.page.ts
@@ -426,4 +426,47 @@ export class PomodoroPage {
       await expect(skipOption).not.toBeVisible({ timeout: 3000 });
     }
   }
+
+  async editTask(taskName: string) {
+    const taskItem = this.page.locator('.task-row').filter({ hasText: taskName }).first();
+    await taskItem.locator('button[aria-label="Edit task"]').click();
+    await this.page.locator('.task-edit-panel').waitFor({ state: 'visible', timeout: 5000 });
+  }
+
+  async saveTaskEdit() {
+    await this.page.locator('.tep-save-btn').click();
+    await this.page.locator('.task-edit-panel').waitFor({ state: 'hidden', timeout: 5000 });
+  }
+
+  async cancelTaskEdit() {
+    await this.page.locator('.tep-cancel-btn').click();
+    await this.page.locator('.task-edit-panel').waitFor({ state: 'hidden', timeout: 5000 });
+  }
+
+  async setTaskRepeat(type: string) {
+    await this.page.locator('.tep-select').selectOption(type);
+  }
+
+  async setTaskScheduleDate(dateStr: string) {
+    await this.page.locator('.tep-row').filter({ hasText: 'Schedule' }).locator('input[type="date"]').fill(dateStr);
+  }
+
+  async toggleTaskPause() {
+    await this.page.locator('.tep-toggle').click();
+  }
+
+  async hasRepeatBadge(taskName: string): Promise<boolean> {
+    const taskItem = this.page.locator('.task-row').filter({ hasText: taskName }).first();
+    return await taskItem.locator('.task-badge.task-repeat').isVisible().catch(() => false);
+  }
+
+  async hasScheduleBadge(taskName: string): Promise<boolean> {
+    const taskItem = this.page.locator('.task-row').filter({ hasText: taskName }).first();
+    return await taskItem.locator('.task-badge.task-scheduled').isVisible().catch(() => false);
+  }
+
+  async hasPausedBadge(taskName: string): Promise<boolean> {
+    const taskItem = this.page.locator('.task-row').filter({ hasText: taskName }).first();
+    return await taskItem.locator('.task-badge.repeat-paused').isVisible().catch(() => false);
+  }
 }

--- a/tests/e2e/pages/repeat-tasks.spec.ts
+++ b/tests/e2e/pages/repeat-tasks.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { PomodoroPage } from '../fixtures/pomodoro.page';
+
+test.describe('Repeat Tasks', () => {
+  let page: PomodoroPage;
+
+  test.beforeEach(async ({ page: p }) => {
+    page = new PomodoroPage(p);
+    await page.goto('/');
+  });
+
+  test('set daily repeat on task shows badge', async () => {
+    await page.addTask('Daily Task');
+    await page.editTask('Daily Task');
+    await page.setTaskRepeat('Daily');
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Daily Task' }).locator('.task-badge.task-repeat')).toBeVisible();
+  });
+
+  test('set weekly repeat with day selection', async () => {
+    await page.addTask('Weekly Task');
+    await page.editTask('Weekly Task');
+    await page.setTaskRepeat('Weekly');
+    await page.page.locator('.tep-weekday-btn').filter({ hasText: 'Mo' }).click();
+    await page.page.locator('.tep-weekday-btn').filter({ hasText: 'We' }).click();
+    await page.page.locator('.tep-weekday-btn').filter({ hasText: 'Fr' }).click();
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Weekly Task' }).locator('.task-badge.task-repeat')).toBeVisible();
+  });
+
+  test('set custom repeat with N days', async () => {
+    await page.addTask('Custom Task');
+    await page.editTask('Custom Task');
+    await page.setTaskRepeat('Custom');
+    await page.page.locator('.tep-input-sm').fill('3');
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Custom Task' }).locator('.task-badge.task-repeat')).toBeVisible();
+  });
+
+  test('set monthly repeat', async () => {
+    await page.addTask('Monthly Task');
+    await page.editTask('Monthly Task');
+    await page.setTaskRepeat('Monthly');
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Monthly Task' }).locator('.task-badge.task-repeat')).toBeVisible();
+  });
+
+  test('pause recurring task shows paused badge', async () => {
+    await page.addTask('Paused Task');
+    await page.editTask('Paused Task');
+    await page.setTaskRepeat('Daily');
+    await page.toggleTaskPause();
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Paused Task' }).locator('.task-badge.repeat-paused')).toBeVisible();
+  });
+
+  test('cancel edit does not save repeat', async () => {
+    await page.addTask('No Repeat Task');
+    await page.editTask('No Repeat Task');
+    await page.setTaskRepeat('Daily');
+    await page.cancelTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'No Repeat Task' }).locator('.task-badge.task-repeat')).not.toBeVisible();
+  });
+
+  test('recurring task stays in list after completion', async () => {
+    await page.addTask('Recurring Complete');
+    await page.editTask('Recurring Complete');
+    await page.setTaskRepeat('Daily');
+    await page.saveTaskEdit();
+    await page.selectTask('Recurring Complete');
+    await page.fastSetup1MinPomodoro();
+    await page.startTimer();
+    await page.completePomodoroFast();
+    await page.skipConsentModal();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Recurring Complete' })).toBeVisible();
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Recurring Complete' }).locator('.task-checkbox')).not.toHaveClass('completed');
+  });
+});

--- a/tests/e2e/pages/resume-interrupted-pomodoro.spec.ts
+++ b/tests/e2e/pages/resume-interrupted-pomodoro.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { PomodoroPage } from '../fixtures/pomodoro.page';
+
+test.describe('Resume Interrupted Pomodoro', () => {
+  let page: PomodoroPage;
+
+  test.describe.configure({ timeout: 180000 });
+
+  test.beforeEach(async ({ page: p }) => {
+    page = new PomodoroPage(p);
+  });
+
+  test('should show Resume Pomodoro option in consent modal after interrupting for break', async () => {
+    await page.goto('/settings');
+    await expect(page.page.locator('.sett-body')).toBeVisible({ timeout: 30000 });
+    await page.setPomodoroMinutes(1);
+
+    const shortBreakInput = page.page.locator('.step-input').nth(1);
+    const shortBreakVal = parseInt(await shortBreakInput.inputValue());
+    const shortBreakDiff = 1 - shortBreakVal;
+    if (shortBreakDiff !== 0) {
+      const btnLabel = shortBreakDiff > 0 ? 'Increase' : 'Decrease';
+      const btn = page.page.locator('.step-btn[aria-label="' + btnLabel + '"]').nth(1);
+      for (let i = 0; i < Math.abs(shortBreakDiff); i++) {
+        await btn.click();
+        await page.page.waitForTimeout(50);
+      }
+    }
+
+    await page.goto('/');
+    await expect(page.page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    await page.addTask('Interrupt Test');
+    await page.selectTask('Interrupt Test');
+    await page.startTimer();
+
+    await page.page.clock.fastForward(30000);
+    const timeBeforeSwitch = await page.getTimerDisplay();
+
+    await page.switchToShortBreak();
+    await expect(page.page.locator('.timer-mode-label')).toContainText('SHORT BREAK', { timeout: 5000 });
+
+    await page.startTimer();
+    await page.completePomodoroFast();
+
+    await expect(page.page.locator('.consent-modal-overlay')).toBeVisible({ timeout: 10000 });
+    await expect(page.page.locator('.btn-option').filter({ hasText: 'Resume Pomodoro' })).toBeVisible();
+    await expect(page.page.locator('.btn-option').filter({ hasText: 'Resume Pomodoro' })).toHaveClass(/default/);
+
+    await page.page.locator('.btn-option').filter({ hasText: 'Resume Pomodoro' }).click();
+    await expect(page.page.locator('.consent-modal-overlay')).not.toBeVisible({ timeout: 5000 });
+
+    await expect(page.page.locator('.timer-mode-label')).toContainText('FOCUSING');
+    const timeAfterResume = await page.getTimerDisplay();
+    expect(timeAfterResume).not.toBe('25:00');
+    expect(timeAfterResume).toBe(timeBeforeSwitch);
+  });
+
+  test('should not show Resume Pomodoro when no pomodoro was interrupted', async () => {
+    await page.goto('/settings');
+    await expect(page.page.locator('.sett-body')).toBeVisible({ timeout: 30000 });
+    await page.setPomodoroMinutes(1);
+    await page.goto('/');
+    await expect(page.page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    await page.addTask('No Interrupt Test');
+    await page.selectTask('No Interrupt Test');
+    await page.startTimer();
+    await page.completePomodoroFast();
+
+    await expect(page.page.locator('.consent-modal-overlay')).toBeVisible({ timeout: 10000 });
+    await expect(page.page.locator('.btn-option').filter({ hasText: 'Resume Pomodoro' })).not.toBeVisible();
+    await page.skipConsentModal();
+  });
+});

--- a/tests/e2e/pages/schedule-tasks.spec.ts
+++ b/tests/e2e/pages/schedule-tasks.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { PomodoroPage } from '../fixtures/pomodoro.page';
+
+test.describe('Schedule Tasks', () => {
+  let page: PomodoroPage;
+
+  test.beforeEach(async ({ page: p }) => {
+    page = new PomodoroPage(p);
+    await page.goto('/');
+  });
+
+  test('schedule task for future date shows schedule badge', async () => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 7);
+    const dateStr = futureDate.toISOString().split('T')[0];
+
+    await page.addTask('Future Task');
+    await page.editTask('Future Task');
+    await page.setTaskScheduleDate(dateStr);
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Future Task' }).locator('.task-badge.task-scheduled')).toBeVisible();
+  });
+
+  test('scheduled task for today is visible in task list', async () => {
+    const todayStr = new Date().toISOString().split('T')[0];
+
+    await page.addTask('Today Task');
+    await page.editTask('Today Task');
+    await page.setTaskScheduleDate(todayStr);
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Today Task' })).toBeVisible();
+  });
+
+  test('schedule date available without repeat', async () => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 3);
+    const dateStr = futureDate.toISOString().split('T')[0];
+
+    await page.addTask('Schedule Only');
+    await page.editTask('Schedule Only');
+    await page.setTaskScheduleDate(dateStr);
+    await page.saveTaskEdit();
+
+    await expect(page.page.locator('.task-row').filter({ hasText: 'Schedule Only' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Added 83 new unit tests covering TaskEditPanel, TaskItemComponent, TaskList, TimerDisplay, WeeklyMiniChart, Index page, History page, and TaskService
- Coverage improved from 97% to 99.3% (6078/6119 lines covered)
- Updated codecov threshold from 98% to 99%

## Coverage Details
- TaskEditPanel: 0% to 95.4% (ToggleWeekday, HandleSave, OnInitialized tests)
- TaskItemComponent: 97.9% to 100% (tooltip, edit badge tests)
- TaskList: 94.9% to 98.5% (HandleTaskEdit callback test)
- TimerDisplay: 98.4% to 100% (CurrentIsRunning property test)
- WeeklyMiniChart: 98% to 100% (DictionariesEqual, parameter change skip tests)
- Index page: 58% to 60% (exception paths, success paths, cache behavior)
- History page: 82% to 82.1% (UpdateFormattedDate tests)
- TaskService: 99% to 99.5% (endDate boundary test)

## Remaining Uncovered Lines (41)
- Program.cs entry point (5 lines) - cannot unit test
- CloudSyncService Task.Run/timer callbacks (14 lines) - async fire-and-forget patterns
- TaskService/ImportService dead code (5 lines) - unreachable switch defaults
- Razor template lines (13 lines) - loading states, conditional rendering
- Index code-behind closing braces (4 lines) - coverage tool branch tracking

Closes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across UI and logic: task editing flow, list interactions, repeat/schedule badges, recurring-task rules and edge cases, history/timer behaviors, chart re-render stability, branch/error paths, and numerous component/unit scenarios.
* **Chores**
  * Increased code coverage targets from 98% to 99.5%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->