### PR TITLE
fix: resolve CodeRabbit feedback from PR #66

### DIFF
--- a/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/IndexCoverageTests.cs
@@ -172,7 +172,7 @@ public class IndexCoverageTests : TestHelper
         TimerServiceMock.Setup(x => x.StartPomodoroAsync(taskId)).Returns(Task.CompletedTask);
         var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
 
-        await cut.Instance.HandleTimerStart();
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerStart());
 
         TimerServiceMock.Verify(x => x.StartPomodoroAsync(taskId), Times.Once);
     }
@@ -184,7 +184,7 @@ public class IndexCoverageTests : TestHelper
         var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
         cut.Instance.CurrentSessionType = SessionType.ShortBreak;
 
-        await cut.Instance.HandleTimerStart();
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerStart());
 
         TimerServiceMock.Verify(x => x.StartShortBreakAsync(), Times.Once);
     }
@@ -196,7 +196,7 @@ public class IndexCoverageTests : TestHelper
         var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
         cut.Instance.CurrentSessionType = SessionType.LongBreak;
 
-        await cut.Instance.HandleTimerStart();
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerStart());
 
         TimerServiceMock.Verify(x => x.StartLongBreakAsync(), Times.Once);
     }
@@ -208,7 +208,7 @@ public class IndexCoverageTests : TestHelper
         var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
         cut.Instance.CurrentSessionType = SessionType.ShortBreak;
 
-        await cut.Instance.HandleTimerStart();
+        await cut.InvokeAsync(() => cut.Instance.HandleTimerStart());
 
         cut.Instance.ErrorMessage.Should().Contain("start error");
     }


### PR DESCRIPTION
Resolves remaining CodeRabbit review comments from PR #66:
- Use \cut.InvokeAsync()\ instead of direct \cut.Instance.HandleTimerStart()\ calls in IndexCoverageTests for proper bUnit renderer sync context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test coverage for timer initialization processes to ensure proper async handling across multiple timer start scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->