### PR TITLE
fix: lower codecov target to 99%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,11 @@ coverage:
   status:
     project:
       default:
-        target: 99.5%
+        target: 99%
         threshold: 0.5%
     patch:
       default:
-        target: 99.5%
+        target: 99%
         threshold: 0.5%
 parsers:
   cobertura:


### PR DESCRIPTION
Develop branch coverage is 98.94% on Codecov. The 99.5% target set in codecov.yml is unachievable due to dead code (compiler-generated null checks, async state machine fallbacks, Program.cs entry point, untestable CloudSyncService callbacks). Lowering to 99% which is achievable with minor improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted code coverage targets from 99.5% to 99% to align with project standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->