### PR TITLE
fix: address CodeRabbit feedback and raise coverage to 99.54%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,11 @@ coverage:
   status:
     project:
       default:
-        target: 99%
+        target: 99.5%
         threshold: 0.5%
     patch:
       default:
-        target: 99%
+        target: 99.5%
         threshold: 0.5%
 parsers:
   cobertura:

--- a/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
@@ -217,6 +217,28 @@ public class CloudSyncServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InitializeAsync_WhenGoogleDriveFailsAllRetries_StillSetsInitialized()
+    {
+        var state = new SyncStateRecord
+        {
+            ClientId = "test-client-id",
+            IsConnected = true,
+            AccessToken = "test-token"
+        };
+        _mockIndexedDb
+            .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
+            .ReturnsAsync(state);
+        _mockGoogleDrive
+            .Setup(g => g.InitializeAsync("test-client-id"))
+            .ThrowsAsync(new Exception("Google Drive init failed"));
+
+        await _sut.InitializeAsync();
+
+        Assert.True(_sut.IsInitialized);
+        _mockGoogleDrive.Verify(g => g.InitializeAsync("test-client-id"), Times.Exactly(3));
+    }
+
+    [Fact]
     public async Task InitializeAsync_DoesNotReinitialize()
     {
         await _sut.InitializeAsync();


### PR DESCRIPTION
## Summary - Restore codecov.yml target from 99%% to 99.5%% (resolves CodeRabbit feedback on PR #66) - Add test for CloudSyncService InitializeAsync fallback when Google Drive fails all 3 retries, covering previously uncovered lines 146-147 - Line coverage: 6091/6119 = 99.54%% (above 99.5%% target)  Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for cloud synchronization initialization resilience under failure conditions.

* **Chores**
  * Updated code coverage enforcement targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->