### PR TITLE
test: improve code coverage from 99.5% to 99.7%

### DIFF
--- a/tests/Pomodoro.Web.Tests/Pages/ErrorBoundaryCoverageTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/ErrorBoundaryCoverageTests.cs
@@ -1,0 +1,119 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Pomodoro.Web.Models;
+using Pomodoro.Web.Pages;
+using Pomodoro.Web.Services;
+using Xunit;
+
+namespace Pomodoro.Web.Tests.Pages;
+
+[Trait("Category", "Component")]
+public class HistoryErrorBoundaryTests : TestHelper
+{
+    public HistoryErrorBoundaryTests()
+    {
+        ActivityServiceMock.Setup(x => x.GetActivitiesPagedAsync(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivitiesForDate(It.IsAny<DateTime>()))
+            .Returns(new List<ActivityRecord>());
+        ActivityServiceMock.Setup(x => x.GetActivityCountAsync(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(0);
+        ActivityServiceMock.Setup(x => x.GetDailyFocusMinutes(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        ActivityServiceMock.Setup(x => x.GetDailyBreakMinutes(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new Dictionary<DateTime, int>());
+        StatisticsServiceMock.Setup(x => x.GetWeeklyStatsAsync(It.IsAny<DateTime>()))
+            .ReturnsAsync(new WeeklyStats());
+        ActivityServiceMock.Setup(x => x.InitializeAsync()).Returns(Task.CompletedTask);
+        InfiniteScrollInteropMock.Setup(x => x.IsSupportedAsync()).ReturnsAsync(false);
+    }
+
+    [Fact]
+    public void DailyViewErrorBoundary_RendersErrorContent_WhenRenderThrows()
+    {
+        var mockPresenter = new Mock<HistoryPagePresenterService>(
+            new Mock<ILogger<HistoryPagePresenterService>>().Object);
+        mockPresenter.Setup(x => x.FormatFocusTime(It.IsAny<int>()))
+            .Throws(new Exception("Render error"));
+        Services.AddSingleton(mockPresenter.Object);
+
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>();
+
+        cut.Find(".section-error").Should().NotBeNull();
+        cut.Find("button.btn-secondary").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DailyViewErrorBoundary_RetryButton_CallsRecover()
+    {
+        var callCount = 0;
+        var mockPresenter = new Mock<HistoryPagePresenterService>(
+            new Mock<ILogger<HistoryPagePresenterService>>().Object);
+        mockPresenter.Setup(x => x.FormatFocusTime(It.IsAny<int>()))
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount <= 1) throw new Exception("Render error");
+                return "1h 30m";
+            });
+        Services.AddSingleton(mockPresenter.Object);
+
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>();
+
+        var retryButton = cut.Find("button.btn-secondary");
+        retryButton.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var errorSections = cut.FindAll(".section-error");
+            errorSections.Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public void WeeklyViewErrorBoundary_RendersErrorContent_WhenChildInitThrows()
+    {
+        ActivityServiceMock.Setup(x => x.GetAllActivities())
+            .Throws(new Exception("Init error"));
+
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialActiveTab, HistoryTab.Weekly));
+
+        cut.Find(".section-error").Should().NotBeNull();
+        cut.Find("button.btn-secondary").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WeeklyViewErrorBoundary_RetryButton_CallsRecover()
+    {
+        var callCount = 0;
+        ActivityServiceMock.Setup(x => x.GetAllActivities())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount <= 1) throw new Exception("Init error");
+                return new List<ActivityRecord>();
+            });
+
+        var cut = RenderComponent<Pomodoro.Web.Pages.History>(parameters =>
+            parameters.Add(p => p.InitialActiveTab, HistoryTab.Weekly));
+
+        var retryButton = cut.Find("button.btn-secondary");
+        retryButton.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var errorSections = cut.FindAll(".section-error");
+            errorSections.Should().BeEmpty();
+        });
+    }
+}

--- a/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
@@ -1379,6 +1380,64 @@ public class CloudSyncServiceTests : IDisposable
 
         Assert.NotNull(timer);
         timer!.Dispose();
+    }
+
+    [Fact]
+    public async Task StartPeriodicSync_TimerCallback_WhenConnected_Syncs()
+    {
+        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
+        _mockGoogleDrive.Setup(g => g.ConnectAsync()).ReturnsAsync("token");
+        _mockGoogleDrive.Setup(g => g.FindSyncFileAsync()).ReturnsAsync((string?)null);
+        _mockExportService.Setup(e => e.ExportToJsonStringAsync()).ReturnsAsync("{}");
+        _mockJsRuntime.Setup(js => js.InvokeAsync<string>(
+            Constants.CompressionJsFunctions.GzipCompress, It.IsAny<object?[]>()))
+            .ReturnsAsync("compressed");
+        _mockGoogleDrive.Setup(g => g.CreateFileAsync(
+            Constants.Sync.SyncFileName, It.IsAny<string>()))
+            .ReturnsAsync("file-id");
+
+        await _sut.ConnectAsync("test-client");
+
+        var field = typeof(CloudSyncService).GetField("_periodicSyncTimer",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var timer = (Timer?)field?.GetValue(_sut);
+        Assert.NotNull(timer);
+
+        timer!.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(-1));
+        await Task.Delay(500);
+
+        _mockGoogleDrive.Verify(g => g.FindSyncFileAsync(), Times.AtLeast(2));
+        timer.Dispose();
+    }
+
+    [Fact]
+    public async Task StartPeriodicSync_TimerCallback_WhenDisconnected_DoesNotSync()
+    {
+        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
+        _mockGoogleDrive.Setup(g => g.ConnectAsync()).ReturnsAsync("token");
+        _mockGoogleDrive.Setup(g => g.FindSyncFileAsync()).ReturnsAsync((string?)null);
+        _mockExportService.Setup(e => e.ExportToJsonStringAsync()).ReturnsAsync("{}");
+        _mockJsRuntime.Setup(js => js.InvokeAsync<string>(
+            Constants.CompressionJsFunctions.GzipCompress, It.IsAny<object?[]>()))
+            .ReturnsAsync("compressed");
+        _mockGoogleDrive.Setup(g => g.CreateFileAsync(
+            Constants.Sync.SyncFileName, It.IsAny<string>()))
+            .ReturnsAsync("file-id");
+
+        await _sut.ConnectAsync("test-client");
+
+        var field = typeof(CloudSyncService).GetField("_periodicSyncTimer",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var timer = (Timer?)field?.GetValue(_sut);
+        Assert.NotNull(timer);
+
+        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(false);
+
+        timer!.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(-1));
+        await Task.Delay(500);
+
+        _mockExportService.Verify(e => e.ExportToJsonStringAsync(), Times.Once);
+        timer.Dispose();
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Line coverage improved from 99.5% (6116/6142) to 99.7% (6126/6142)
- 10 additional lines covered, 16 remaining (all dead code)

## New Tests (6)

### ErrorBoundary retry button coverage (ErrorBoundaryCoverageTests.cs)
- DailyViewErrorBoundary_RendersErrorContent_WhenRenderThrows — covers History.razor line 42
- DailyViewErrorBoundary_RetryButton_CallsRecover — covers retry button click
- WeeklyViewErrorBoundary_RendersErrorContent_WhenChildInitThrows — covers History.razor line 72
- WeeklyViewErrorBoundary_RetryButton_CallsRecover — covers retry button click

### CloudSyncService periodic sync timer callback (CloudSyncServiceTests.cs)
- StartPeriodicSync_TimerCallback_WhenConnected_Syncs — covers lines 406-414 (timer callback with sync)
- StartPeriodicSync_TimerCallback_WhenDisconnected_DoesNotSync — covers line 407 (early return when disconnected)

## Remaining 16 uncovered lines (all dead code)
- Program.cs (5) — entry point, not testable
- TaskItemBase line 94 — exhaustive switch default, unreachable
- TaskService lines 342, 365 — exhaustive switch default and unreachable fallback
- CloudSyncService lines 284-287 — PushAsync catches all exceptions internally
- Index.razor line 93 — ErrorBoundary retry button (no injectable service to trigger render error)
- IndexBase line 60 — generated code artifact

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive error boundary test coverage for History page views (daily and weekly).
  * Added timer callback tests for cloud synchronization service behavior.

**Note:** These are internal quality improvements with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->