### PR TITLE
fix(ci): use line coverage 99.5% threshold and resolve coverage file path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 on:
+  push:
+    branches: [develop]
   pull_request:
     branches: [main, develop]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -78,7 +80,7 @@ jobs:
           DISPLAY_PERCENT=$(awk "BEGIN {printf \"%.2f\", ($COVERED/$TOTAL)*100}")
           echo "Line coverage: $COVERED/$TOTAL ($DISPLAY_PERCENT%)"
           THRESHOLD=99.5
-          PASS=$(awk "BEGIN {print (($COVERED/$TOTAL)*100 >= $THRESHOLD) ? 1 : 0}")
+          PASS=$(awk "BEGIN {print (($COVERED/$TOTAL)*100 > $THRESHOLD) ? 1 : 0}")
           if [ "$PASS" -eq 0 ]; then
             echo "::error::Line coverage ${DISPLAY_PERCENT}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,17 @@ jobs:
       - name: Resolve coverage file
         id: coverage
         run: |
-          COVERAGE_FILE=$(find ./coverage -name "coverage.cobertura.xml" | head -1)
-          if [ -z "$COVERAGE_FILE" ] || [ ! -f "$COVERAGE_FILE" ]; then
+          mapfile -t COVERAGE_FILES < <(find ./coverage -type f -name "coverage.cobertura.xml" | sort)
+          if [ "${#COVERAGE_FILES[@]}" -eq 0 ]; then
             echo "::error::No coverage report found"
             exit 1
           fi
+          if [ "${#COVERAGE_FILES[@]}" -gt 1 ]; then
+            echo "::error::Multiple coverage reports found:"
+            printf '%s\n' "${COVERAGE_FILES[@]}"
+            exit 1
+          fi
+          COVERAGE_FILE="${COVERAGE_FILES[0]}"
           echo "file=$COVERAGE_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Check line coverage
@@ -80,7 +86,7 @@ jobs:
           DISPLAY_PERCENT=$(awk "BEGIN {printf \"%.2f\", ($COVERED/$TOTAL)*100}")
           echo "Line coverage: $COVERED/$TOTAL ($DISPLAY_PERCENT%)"
           THRESHOLD=99.5
-          PASS=$(awk "BEGIN {print (($COVERED/$TOTAL)*100 > $THRESHOLD) ? 1 : 0}")
+          PASS=$(awk "BEGIN {print (($COVERED/$TOTAL)*100 >= $THRESHOLD) ? 1 : 0}")
           if [ "$PASS" -eq 0 ]; then
             echo "::error::Line coverage ${DISPLAY_PERCENT}% is below threshold ${THRESHOLD}%"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,33 +56,39 @@ jobs:
       - run: dotnet test Pomodoro.sln --configuration Release --verbosity normal
             --collect:"XPlat Code Coverage" --results-directory ./coverage
 
-      - name: Check branch coverage
+      - name: Resolve coverage file
+        id: coverage
         run: |
           COVERAGE_FILE=$(find ./coverage -name "coverage.cobertura.xml" | head -1)
           if [ -z "$COVERAGE_FILE" ] || [ ! -f "$COVERAGE_FILE" ]; then
             echo "::error::No coverage report found"
             exit 1
           fi
-          COVERED=$(grep -oP 'branches-covered="\K[0-9]+' "$COVERAGE_FILE" | head -1)
-          TOTAL=$(grep -oP 'branches-valid="\K[0-9]+' "$COVERAGE_FILE" | head -1)
+          echo "file=$COVERAGE_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Check line coverage
+        run: |
+          COVERAGE_FILE="${{ steps.coverage.outputs.file }}"
+          COVERED=$(grep -oP 'lines-covered="\K[0-9]+' "$COVERAGE_FILE" | head -1)
+          TOTAL=$(grep -oP 'lines-valid="\K[0-9]+' "$COVERAGE_FILE" | head -1)
           if [ -z "$COVERED" ] || [ -z "$TOTAL" ] || [ "$TOTAL" -eq 0 ]; then
-            echo "::error::Could not parse branch coverage from report"
+            echo "::error::Could not parse line coverage from report"
             exit 1
           fi
-          DISPLAY_PERCENT=$(awk "BEGIN {printf \"%.1f\", ($COVERED/$TOTAL)*100}")
-          echo "Branch coverage: $COVERED/$TOTAL ($DISPLAY_PERCENT%)"
-          THRESHOLD=98.0
+          DISPLAY_PERCENT=$(awk "BEGIN {printf \"%.2f\", ($COVERED/$TOTAL)*100}")
+          echo "Line coverage: $COVERED/$TOTAL ($DISPLAY_PERCENT%)"
+          THRESHOLD=99.5
           PASS=$(awk "BEGIN {print (($COVERED/$TOTAL)*100 >= $THRESHOLD) ? 1 : 0}")
           if [ "$PASS" -eq 0 ]; then
-            echo "::error::Branch coverage ${DISPLAY_PERCENT}% is below threshold ${THRESHOLD}%"
+            echo "::error::Line coverage ${DISPLAY_PERCENT}% is below threshold ${THRESHOLD}%"
             exit 1
           fi
-          echo "Branch coverage meets threshold"
+          echo "Line coverage meets threshold"
 
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/**/coverage.cobertura.xml
+          files: ${{ steps.coverage.outputs.file }}
           fail_ci_if_error: false
           verbose: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,11 +6,11 @@ coverage:
     project:
       default:
         target: 99.5%
-        threshold: 0.5%
+        threshold: 0%
     patch:
       default:
-        target: 99.5%
-        threshold: 0.5%
+        target: 100%
+        threshold: 0%
 parsers:
   cobertura:
     partials_as_hits: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     patch:
       default:
         target: 100%
-        threshold: 0%
+        threshold: 0.5%
 parsers:
   cobertura:
     partials_as_hits: true


### PR DESCRIPTION
## Summary
- Changed CI coverage check from branch coverage (98%) to line coverage (99.5%) to match `codecov.yml` target
- Fixed coverage file glob pattern — `./coverage/**/coverage.cobertura.xml` was not expanded by shell, now uses `find` to resolve actual path via `$GITHUB_OUTPUT`
- Codecov upload now receives the resolved file path instead of an unexpanded glob

Closes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs on both PRs and direct pushes to develop, with improved concurrency handling.
  * Unit-test coverage was reworked into explicit resolution and line-coverage verification steps enforcing a 99.5% line threshold; coverage upload consumes the resolved report path.
  * Branch-coverage flow removed; coverage thresholds adjusted (project default lowered, patch-level tightened to 100%).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->