### PR TITLE
fix: simplify deploy workflow to single branch dropdown

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'production' || 'preview' }}
+    environment: ${{ (github.ref_name == 'main' || inputs.branch == 'main') && 'production' || 'preview' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,13 +3,19 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'develop'
+        type: string
 
 permissions:
   contents: read
   deployments: write
 
 concurrency:
-  group: deploy-${{ github.ref_name }}
+  group: deploy-${{ github.event_name == 'push' && github.ref_name || inputs.branch }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || inputs.branch }}
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -55,5 +63,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: pomodoro
-          branch: ${{ github.ref_name }}
+          branch: ${{ github.event_name == 'push' && github.ref_name || inputs.branch }}
           directory: publish/wwwroot

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,10 @@ on:
         description: 'Branch to deploy'
         required: true
         default: 'develop'
-        type: string
+        type: choice
+        options:
+          - develop
+          - main
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,18 +3,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to deploy as preview'
-        required: true
-        default: 'develop'
 
 permissions:
   contents: read
   deployments: write
 
 concurrency:
-  group: deploy-${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -22,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -48,7 +41,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'push' && 'production' || 'preview' }}
+    environment: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'production' || 'preview' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -62,5 +55,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: pomodoro
-          branch: ${{ github.event_name == 'push' && 'main' || inputs.branch }}
+          branch: ${{ github.ref_name }}
           directory: publish/wwwroot

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: ${{ (github.ref_name == 'main' || inputs.branch == 'main') && 'production' || 'preview' }}
+    environment: ${{ ((github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_dispatch' && inputs.branch == 'main')) && 'production' || 'preview' }}
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Closes #77

Add inputs.branch to deploy workflow_dispatch (default: develop). Use it for checkout ref, concurrency group, and Cloudflare branch name. Push-to-main still auto-deploys to production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now targets production only for the main branch; other branches deploy to preview.
  * Builds and deployments respect the actual branch for both push and manual runs.
  * Concurrency grouping refined to isolate deploys per branch and reduce conflicting runs.
  * Cloudflare Pages publishing follows the branch of the run instead of a fixed branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->