### PR TITLE
fix: improve PiP window with per-session themes, three-state controls, and visual refinements

### DIFF
--- a/mock/pip_redesign.html
+++ b/mock/pip_redesign.html
@@ -3,14 +3,13 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>PiP Window — Redesigned</title>
+<title>PiP Window — Fix V2 Mock (3 States)</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #080d18; font-family: system-ui, -apple-system, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; gap: 40px; padding: 32px; }
+  body { background: #080d18; font-family: system-ui, -apple-system, sans-serif; display: flex; align-items: flex-start; justify-content: center; min-height: 100vh; gap: 40px; padding: 32px; flex-wrap: wrap; }
 
   .label { font-size: 10px; font-weight: 700; letter-spacing: .09em; color: #3a4060; text-align: center; margin-bottom: 10px; }
 
-  /* PiP outer chrome — browser window simulation */
   .pip-chrome {
     width: 340px;
     border-radius: 12px;
@@ -29,21 +28,13 @@
   }
   .pip-title-left { display: flex; align-items: center; gap: 6px; }
   .pip-title-left span { font-size: 11px; color: rgba(255,255,255,0.45); }
-  .pip-title-btns { display: flex; gap: 5px; }
-  .pip-tbtn {
-    width: 16px; height: 16px; border-radius: 3px;
-    background: rgba(255,255,255,0.08);
-    display: flex; align-items: center; justify-content: center;
-  }
 
-  /* PiP content */
   .pip-body {
     background: #162032;
     display: flex;
     flex-direction: column;
   }
 
-  /* Session tabs — compact */
   .pip-tabs {
     display: flex;
     padding: 6px 10px 0;
@@ -53,27 +44,35 @@
   .pip-tab {
     flex: 1; padding: 7px 0; border-radius: 7px 7px 0 0;
     border: none; background: transparent;
-    font-size: 12px; font-weight: 400;
+    font-size: 13px; font-weight: 400;
     color: rgba(255,255,255,0.3);
     cursor: pointer; font-family: system-ui;
     border-bottom: 2px solid transparent;
   }
   .pip-tab.act {
     color: #e8edf8; font-weight: 600;
-    border-bottom-color: #D85A30;
+    border-bottom-color: #e74c3c;
   }
+  .pip-tab.act.short-break { border-bottom-color: #27ae60; }
+  .pip-tab.act.long-break { border-bottom-color: #3498db; }
 
-  /* Timer area — ring fills the space */
   .pip-timer-area {
     display: flex;
     flex-direction: column;
     align-items: center;
     padding: 20px 20px 16px;
     gap: 14px;
-    background: linear-gradient(160deg, #1e2a50, #162032);
+  }
+  .pip-container.pomodoro-theme .pip-timer-area {
+    background: linear-gradient(180deg, rgba(231,76,60,.12), #162032);
+  }
+  .pip-container.short-break-theme .pip-timer-area {
+    background: linear-gradient(180deg, rgba(39,174,96,.12), #162032);
+  }
+  .pip-container.long-break-theme .pip-timer-area {
+    background: linear-gradient(180deg, rgba(52,152,219,.12), #162032);
   }
 
-  /* Ring */
   .ring-wrap { position: relative; }
   .ring-wrap svg { display: block; transform: rotate(-90deg); }
   .ring-center {
@@ -81,10 +80,14 @@
     transform: translate(-50%, -50%);
     text-align: center;
   }
-  .ring-time { font-size: 42px; font-weight: 700; color: #e8edf8; letter-spacing: -1px; line-height: 1; }
-  .ring-label { font-size: 11px; color: #8a97b8; letter-spacing: .1em; margin-top: 5px; }
+  .ring-time {
+    font-size: 42px; font-weight: 700; color: #e8edf8;
+    letter-spacing: -1px; line-height: 1;
+    font-family: 'Courier New', 'Lucida Console', monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  .ring-label { font-size: 12px; color: #8a97b8; letter-spacing: .1em; margin-top: 5px; }
 
-  /* Active task pill */
   .pip-task {
     width: 100%;
     background: #1e2a40;
@@ -94,17 +97,26 @@
     align-items: center;
     gap: 8px;
   }
-  .pip-task-dot { width: 7px; height: 7px; border-radius: 50%; background: #D85A30; flex-shrink: 0; }
-  .pip-task-name { font-size: 13px; color: #e8edf8; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .pip-task-dot { width: 7px; height: 7px; border-radius: 50%; background: #e74c3c; flex-shrink: 0; }
+  .pip-task-dot.short-break { background: #27ae60; }
+  .pip-task-dot.long-break { background: #3498db; }
+  .pip-task-name { font-size: 13px; color: #e8edf8; flex: 1; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-  /* Controls */
   .pip-ctrl { display: flex; align-items: center; justify-content: center; gap: 16px; }
   .pip-play {
     width: 52px; height: 52px; border-radius: 50%;
-    background: #D85A30; border: none;
+    background: #e74c3c; border: none;
     display: flex; align-items: center; justify-content: center;
     cursor: pointer;
-    box-shadow: 0 4px 18px rgba(216,90,48,.45);
+    box-shadow: 0 4px 18px rgba(231,76,60,.45);
+  }
+  .pip-play.short-break {
+    background: #27ae60;
+    box-shadow: 0 4px 18px rgba(39,174,96,.45);
+  }
+  .pip-play.long-break {
+    background: #3498db;
+    box-shadow: 0 4px 18px rgba(52,152,219,.45);
   }
   .pip-reset {
     width: 36px; height: 36px; border-radius: 50%;
@@ -114,76 +126,169 @@
     cursor: pointer; color: #8a97b8;
   }
 
-  /* Footer */
+  .pip-hint {
+    font-size: 12px;
+    color: #6e7a8a;
+    text-align: center;
+  }
+
   .pip-footer {
     display: flex; align-items: center; justify-content: space-between;
     padding: 10px 20px 14px;
     background: #162032;
   }
-  .pip-footer span { font-size: 11px; }
-  .pip-footer .lbl { color: #4a5470; }
-  .pip-footer .val { color: #8a97b8; font-weight: 600; }
+  .pip-footer span { font-size: 12px; }
+  .pip-footer .lbl { color: #6e7a8a; }
+  .pip-footer .val { color: #a0aec0; font-weight: 600; }
 </style>
 </head>
 <body>
 
+<!-- State 1: Not Started -->
 <div>
+  <div class="label">NOT STARTED</div>
   <div class="pip-chrome">
     <div class="pip-titlebar">
       <div class="pip-title-left">
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="0.5" y="0.5" width="11" height="11" rx="2" stroke="rgba(255,255,255,0.3)" stroke-width="1"/><rect x="3" y="5" width="4" height="3" rx="0.5" fill="rgba(255,255,255,0.5)"/></svg>
         <span>pomodoro.bitops.bd</span>
       </div>
-      <div class="pip-title-btns">
-        <div class="pip-tbtn"><svg width="8" height="8" viewBox="0 0 8 8" fill="none"><path d="M1 1h2M5 1h2M1 5h2M5 5h2M1 7h2M5 7h2" stroke="rgba(255,255,255,0.5)" stroke-width="1" stroke-linecap="round"/></svg></div>
-        <div class="pip-tbtn"><svg width="8" height="8" viewBox="0 0 8 8" fill="none"><path d="M2 2l4 4M6 2l-4 4" stroke="rgba(255,255,255,0.5)" stroke-width="1.2" stroke-linecap="round"/></svg></div>
+    </div>
+    <div class="pip-body">
+      <div class="pip-container pomodoro-theme">
+        <div class="pip-tabs">
+          <button class="pip-tab act">Pomodoro</button>
+          <button class="pip-tab">Short break</button>
+          <button class="pip-tab">Long break</button>
+        </div>
+        <div class="pip-timer-area">
+          <div class="ring-wrap">
+            <svg width="220" height="220" viewBox="0 0 220 220">
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#1e2a40" stroke-width="14"/>
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#e74c3c" stroke-width="14" stroke-linecap="round" stroke-dasharray="553 553"/>
+            </svg>
+            <div class="ring-center">
+              <div class="ring-time">25:00</div>
+              <div class="ring-label">FOCUSING</div>
+            </div>
+          </div>
+          <div class="pip-task">
+            <div class="pip-task-dot"></div>
+            <span class="pip-task-name">website builder ai</span>
+          </div>
+          <div class="pip-ctrl">
+            <button class="pip-play">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 4l10 6-10 6V4z" fill="white"/></svg>
+            </button>
+          </div>
+          <div class="pip-hint">Space to start</div>
+        </div>
+        <div class="pip-footer">
+          <span class="lbl">25 min session</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- State 2: Running -->
+<div>
+  <div class="label">RUNNING</div>
+  <div class="pip-chrome">
+    <div class="pip-titlebar">
+      <div class="pip-title-left">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="0.5" y="0.5" width="11" height="11" rx="2" stroke="rgba(255,255,255,0.3)" stroke-width="1"/><rect x="3" y="5" width="4" height="3" rx="0.5" fill="rgba(255,255,255,0.5)"/></svg>
+        <span>pomodoro.bitops.bd</span>
       </div>
     </div>
     <div class="pip-body">
-      <div class="pip-tabs">
-        <button class="pip-tab act">Pomodoro</button>
-        <button class="pip-tab">Short break</button>
-        <button class="pip-tab">Long break</button>
-      </div>
-
-      <!-- timer area: ring fills available width -->
-      <div class="pip-timer-area">
-
-        <!-- large ring — 220px, matches regular timer -->
-        <div class="ring-wrap">
-          <svg width="220" height="220" viewBox="0 0 220 220">
-            <circle cx="110" cy="110" r="88" fill="none" stroke="#1e2a40" stroke-width="14"/>
-            <circle cx="110" cy="110" r="88" fill="none" stroke="#D85A30" stroke-width="14" stroke-linecap="round" stroke-dasharray="553 553"/>
-          </svg>
-          <div class="ring-center">
-            <div class="ring-time">25:00</div>
-            <div class="ring-label">FOCUSING</div>
+      <div class="pip-container pomodoro-theme running">
+        <div class="pip-tabs">
+          <button class="pip-tab act">Pomodoro</button>
+          <button class="pip-tab">Short break</button>
+          <button class="pip-tab">Long break</button>
+        </div>
+        <div class="pip-timer-area">
+          <div class="ring-wrap">
+            <svg width="220" height="220" viewBox="0 0 220 220">
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#1e2a40" stroke-width="14"/>
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#e74c3c" stroke-width="14" stroke-linecap="round" stroke-dasharray="553 553" stroke-dashoffset="138"/>
+            </svg>
+            <div class="ring-center">
+              <div class="ring-time" style="color:#e74c3c">18:32</div>
+              <div class="ring-label">FOCUSING</div>
+            </div>
+          </div>
+          <div class="pip-task">
+            <div class="pip-task-dot"></div>
+            <span class="pip-task-name">website builder ai</span>
+          </div>
+          <div class="pip-ctrl">
+            <button class="pip-reset">
+              <svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M2.5 7.5A5 5 0 1 0 4.2 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M2.5 2v2.5H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button class="pip-play">
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><rect x="3" y="2" width="4" height="14" rx="1" fill="white"/><rect x="11" y="2" width="4" height="14" rx="1" fill="white"/></svg>
+            </button>
+            <div style="width:36px"></div>
           </div>
         </div>
-
-        <!-- active task -->
-        <div class="pip-task">
-          <div class="pip-task-dot"></div>
-          <span class="pip-task-name">website builder ai</span>
+        <div class="pip-footer">
+          <span class="lbl">Ends at</span>
+          <span class="val">10:47 AM</span>
         </div>
-
-        <!-- controls: reset left, play centre -->
-        <div class="pip-ctrl">
-          <button class="pip-reset">
-            <svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M2.5 7.5A5 5 0 1 0 4.2 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M2.5 2v2.5H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </button>
-          <button class="pip-play">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 4l10 6-10 6V4z" fill="white"/></svg>
-          </button>
-          <!-- spacer to balance reset on left -->
-          <div style="width:36px"></div>
-        </div>
-
       </div>
+    </div>
+  </div>
+</div>
 
-      <div class="pip-footer">
-        <span class="lbl">Ends at</span>
-        <span class="val">10:47 AM</span>
+<!-- State 3: Paused -->
+<div>
+  <div class="label">PAUSED</div>
+  <div class="pip-chrome">
+    <div class="pip-titlebar">
+      <div class="pip-title-left">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><rect x="0.5" y="0.5" width="11" height="11" rx="2" stroke="rgba(255,255,255,0.3)" stroke-width="1"/><rect x="3" y="5" width="4" height="3" rx="0.5" fill="rgba(255,255,255,0.5)"/></svg>
+        <span>pomodoro.bitops.bd</span>
+      </div>
+    </div>
+    <div class="pip-body">
+      <div class="pip-container pomodoro-theme">
+        <div class="pip-tabs">
+          <button class="pip-tab act">Pomodoro</button>
+          <button class="pip-tab">Short break</button>
+          <button class="pip-tab">Long break</button>
+        </div>
+        <div class="pip-timer-area">
+          <div class="ring-wrap">
+            <svg width="220" height="220" viewBox="0 0 220 220">
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#1e2a40" stroke-width="14"/>
+              <circle cx="110" cy="110" r="88" fill="none" stroke="#e74c3c" stroke-width="14" stroke-linecap="round" stroke-dasharray="553 553" stroke-dashoffset="276"/>
+            </svg>
+            <div class="ring-center">
+              <div class="ring-time">12:30</div>
+              <div class="ring-label">FOCUSING</div>
+            </div>
+          </div>
+          <div class="pip-task">
+            <div class="pip-task-dot"></div>
+            <span class="pip-task-name">website builder ai</span>
+          </div>
+          <div class="pip-ctrl">
+            <button class="pip-reset">
+              <svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M2.5 7.5A5 5 0 1 0 4.2 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M2.5 2v2.5H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button class="pip-play">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 4l10 6-10 6V4z" fill="white"/></svg>
+            </button>
+            <div style="width:36px"></div>
+          </div>
+          <div class="pip-hint">Space to resume</div>
+        </div>
+        <div class="pip-footer">
+          <span class="lbl">Paused · ends at</span>
+          <span class="val">10:47 AM</span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/Pomodoro.Web/wwwroot/js/pipTimer.js
+++ b/src/Pomodoro.Web/wwwroot/js/pipTimer.js
@@ -31,7 +31,7 @@ window.pipTimer = {
         }
         
         var width = Math.round(Math.min(window.innerWidth, 420) * 0.9);
-        var height = 460;
+        var height = 440;
         
         if (this.isSupported()) {
             try {
@@ -57,7 +57,7 @@ window.pipTimer = {
     
     openFallback: function(timerState) {
         var width = Math.round(Math.min(window.innerWidth, 420) * 0.9);
-        var height = 460;
+        var height = 440;
         
         const features = [
             'width=' + width,
@@ -145,7 +145,7 @@ window.pipTimer = {
                 border-radius: 7px 7px 0 0;
                 border: none;
                 background: transparent;
-                font-size: 12px;
+                font-size: 13px;
                 font-weight: 400;
                 color: rgba(255,255,255,0.3);
                 cursor: pointer;
@@ -167,13 +167,13 @@ window.pipTimer = {
                 gap: 14px;
             }
             .pip-container.pomodoro-theme .pip-timer-area {
-                background: linear-gradient(160deg, #1e2a50, #162032);
+                background: linear-gradient(180deg, rgba(231,76,60,.12), #162032);
             }
             .pip-container.short-break-theme .pip-timer-area {
-                background: linear-gradient(160deg, #1e2a50, #162032);
+                background: linear-gradient(180deg, rgba(39,174,96,.12), #162032);
             }
             .pip-container.long-break-theme .pip-timer-area {
-                background: linear-gradient(160deg, #1e2a50, #162032);
+                background: linear-gradient(180deg, rgba(52,152,219,.12), #162032);
             }
             .ring-wrap { position: relative; }
             .ring-wrap svg { display: block; transform: rotate(-90deg); }
@@ -203,13 +203,14 @@ window.pipTimer = {
                 color: #e8edf8;
                 letter-spacing: -1px;
                 line-height: 1;
+                font-family: 'Courier New', 'Lucida Console', monospace;
                 font-variant-numeric: tabular-nums;
             }
             .pip-container.running.pomodoro-theme .ring-time { color: #e74c3c; }
             .pip-container.running.short-break-theme .ring-time { color: #27ae60; }
             .pip-container.running.long-break-theme .ring-time { color: #3498db; }
             .ring-label {
-                font-size: 11px;
+                font-size: 12px;
                 color: #8a97b8;
                 letter-spacing: .1em;
                 margin-top: 5px;
@@ -236,6 +237,7 @@ window.pipTimer = {
                 font-size: 13px;
                 color: #e8edf8;
                 flex: 1;
+                max-width: 100%;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
@@ -278,6 +280,11 @@ window.pipTimer = {
                 cursor: pointer;
                 color: #8a97b8;
             }
+            .pip-hint {
+                font-size: 12px;
+                color: #6e7a8a;
+                text-align: center;
+            }
             .pip-footer {
                 display: flex;
                 align-items: center;
@@ -285,9 +292,9 @@ window.pipTimer = {
                 padding: 10px 20px 14px;
                 background: #162032;
             }
-            .pip-footer span { font-size: 11px; }
-            .pip-footer .lbl { color: #4a5470; }
-            .pip-footer .val { color: #8a97b8; font-weight: 600; }
+            .pip-footer span { font-size: 12px; }
+            .pip-footer .lbl { color: #6e7a8a; }
+            .pip-footer .val { color: #a0aec0; font-weight: 600; }
         `;
         this.pipDocument.head.appendChild(pipStyles);
     },
@@ -330,12 +337,13 @@ window.pipTimer = {
 
         var modeLabel = sessionType === 0 ? 'FOCUSING' : sessionType === 1 ? 'SHORT BREAK' : 'LONG BREAK';
         var isRunning = state.isRunning || false;
+        var isStarted = state.isStarted || false;
         var taskName = state.taskName || null;
         var endsAt = state.endsAt || null;
 
-        var playIcon = isRunning
-            ? '<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><rect x="3" y="2" width="4" height="14" rx="1" fill="white"/><rect x="11" y="2" width="4" height="14" rx="1" fill="white"/></svg>'
-            : '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 4l10 6-10 6V4z" fill="white"/></svg>';
+        var playIcon = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 4l10 6-10 6V4z" fill="white"/></svg>';
+        var pauseIcon = '<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><rect x="3" y="2" width="4" height="14" rx="1" fill="white"/><rect x="11" y="2" width="4" height="14" rx="1" fill="white"/></svg>';
+        var resetIcon = '<svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M2.5 7.5A5 5 0 1 0 4.2 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M2.5 2v2.5H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
 
         var html = '<div class="pip-tabs">';
         html += '<button class="pip-tab ' + (sessionType === 0 ? 'act pomodoro' : '') + '" onclick="window.pipSwitchSession(0)">Pomodoro</button>';
@@ -360,23 +368,51 @@ window.pipTimer = {
             html += '</div>';
         }
 
-        html += '<div class="pip-ctrl">';
-        html += '<button class="pip-reset" onclick="window.pipResetTimer()" aria-label="Reset timer">';
-        html += '<svg width="15" height="15" viewBox="0 0 15 15" fill="none"><path d="M2.5 7.5A5 5 0 1 0 4.2 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M2.5 2v2.5H5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-        html += '</button>';
-        html += '<button class="pip-play ' + sessionClass + '" onclick="window.pipToggleTimer()" aria-label="' + (isRunning ? 'Pause' : 'Play') + '">';
-        html += playIcon;
-        html += '</button>';
-        html += '<div style="width:36px"></div>';
-        html += '</div>';
+        if (!isStarted && !isRunning) {
+            html += '<div class="pip-ctrl">';
+            html += '<button class="pip-play ' + sessionClass + '" onclick="window.pipToggleTimer()" aria-label="Start">';
+            html += playIcon;
+            html += '</button>';
+            html += '</div>';
+            html += '<div class="pip-hint">Space to start</div>';
+        } else if (isRunning) {
+            html += '<div class="pip-ctrl">';
+            html += '<button class="pip-reset" onclick="window.pipResetTimer()" aria-label="Reset timer">';
+            html += resetIcon;
+            html += '</button>';
+            html += '<button class="pip-play ' + sessionClass + '" onclick="window.pipToggleTimer()" aria-label="Pause">';
+            html += pauseIcon;
+            html += '</button>';
+            html += '<div style="width:36px"></div>';
+            html += '</div>';
+        } else {
+            html += '<div class="pip-ctrl">';
+            html += '<button class="pip-reset" onclick="window.pipResetTimer()" aria-label="Reset timer">';
+            html += resetIcon;
+            html += '</button>';
+            html += '<button class="pip-play ' + sessionClass + '" onclick="window.pipToggleTimer()" aria-label="Resume">';
+            html += playIcon;
+            html += '</button>';
+            html += '<div style="width:36px"></div>';
+            html += '</div>';
+            html += '<div class="pip-hint">Space to resume</div>';
+        }
         html += '</div>';
 
-        if (isRunning && endsAt) {
-            html += '<div class="pip-footer">';
+        var durationMinutes = Math.round((state.totalDurationSeconds || 0) / 60);
+        html += '<div class="pip-footer">';
+        if (!isStarted && !isRunning) {
+            var durationLabel = sessionType === 0 ? durationMinutes + ' min session'
+                : durationMinutes + ' min break';
+            html += '<span class="lbl">' + durationLabel + '</span>';
+        } else if (isRunning && endsAt) {
             html += '<span class="lbl">Ends at</span>';
             html += '<span class="val">' + endsAt + '</span>';
-            html += '</div>';
+        } else if (isStarted && !isRunning && endsAt) {
+            html += '<span class="lbl">Paused · ends at</span>';
+            html += '<span class="val">' + endsAt + '</span>';
         }
+        html += '</div>';
 
         return html;
     },

--- a/tests/e2e/pages/pip-window-content.spec.ts
+++ b/tests/e2e/pages/pip-window-content.spec.ts
@@ -65,8 +65,8 @@ test.describe('PiP Window Content and Communication', () => {
         ringLabel: doc.querySelector('.ring-label')?.textContent ?? '',
         pipTabs: doc.querySelectorAll('.pip-tab').length,
         pipCtrl: !!doc.querySelector('.pip-ctrl'),
-        toggleBtn: !!doc.querySelector('[onclick="window.pipToggleTimer()"]'),
-        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        toggleBtn: !!doc.querySelector('.pip-play'),
+        resetBtn: !!doc.querySelector('.pip-reset'),
         pipTask: !!doc.querySelector('.pip-task'),
         taskName: doc.querySelector('.pip-task-name')?.textContent ?? '',
         pipFooter: !!doc.querySelector('.pip-footer'),
@@ -111,7 +111,7 @@ test.describe('PiP Window Content and Communication', () => {
         ringLabel: doc.querySelector('.ring-label')?.textContent ?? '',
         ringFill: !!doc.querySelector('.ring-fill.short-break'),
         pipCtrl: !!doc.querySelector('.pip-ctrl'),
-        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        resetBtn: !!doc.querySelector('.pip-reset'),
         pipTask: !!doc.querySelector('.pip-task'),
         pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
         pipFooter: !!doc.querySelector('.pip-footer'),
@@ -254,8 +254,8 @@ test.describe('PiP Window Content and Communication', () => {
       });
       const doc = new DOMParser().parseFromString(html, 'text/html');
       return {
-        toggleBtn: !!doc.querySelector('[onclick="window.pipToggleTimer()"]'),
-        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        toggleBtn: !!doc.querySelector('.pip-play'),
+        resetBtn: !!doc.querySelector('.pip-reset'),
         pipCtrl: !!doc.querySelector('.pip-ctrl'),
         pipTask: !!doc.querySelector('.pip-task'),
         taskName: doc.querySelector('.pip-task-name')?.textContent ?? '',
@@ -296,7 +296,7 @@ test.describe('PiP Window Content and Communication', () => {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       return {
         playBtn: !!doc.querySelector('.pip-play'),
-        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        resetBtn: !!doc.querySelector('.pip-reset'),
         pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
         pipFooter: !!doc.querySelector('.pip-footer'),
         footerText: doc.querySelector('.pip-footer')?.textContent ?? '',
@@ -319,8 +319,10 @@ test.describe('PiP Window Content and Communication', () => {
 
     const hasMonospace = await page.evaluate(() => {
       const pip = (window as any).pipTimer;
-      const source = pip.ensurePipStyles.toString();
-      return source.includes('monospace');
+      const source = pip.injectPipStyles.toString();
+      return source.includes("'Courier New'") &&
+             source.includes("'Lucida Console'") &&
+             source.includes('monospace');
     });
 
     expect(hasMonospace).toBe(true);
@@ -343,7 +345,7 @@ test.describe('PiP Window Content and Communication', () => {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       return {
         playBtn: !!doc.querySelector('.pip-play'),
-        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        resetBtn: !!doc.querySelector('.pip-reset'),
         pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
         pipFooter: !!doc.querySelector('.pip-footer'),
         footerText: doc.querySelector('.pip-footer')?.textContent ?? '',

--- a/tests/e2e/pages/pip-window-content.spec.ts
+++ b/tests/e2e/pages/pip-window-content.spec.ts
@@ -317,7 +317,7 @@ test.describe('PiP Window Content and Communication', () => {
   test('should use monospace font for timer digits', async ({ page }) => {
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
-    const fontFamily = await page.evaluate(() => {
+    const hasMonospace = await page.evaluate(() => {
       const pip = (window as any).pipTimer;
       const html = pip.generateTimerHTML({
         sessionType: 0,
@@ -328,11 +328,11 @@ test.describe('PiP Window Content and Communication', () => {
         taskName: null
       });
       const doc = new DOMParser().parseFromString(html, 'text/html');
-      const style = doc.querySelector('.ring-time');
-      return style?.getAttribute('style') ?? '';
+      const styleEl = doc.querySelector('style');
+      return styleEl?.textContent?.includes('.ring-time') && styleEl?.textContent?.includes('monospace');
     });
 
-    expect(fontFamily).toContain('monospace');
+    expect(hasMonospace).toBe(true);
   });
 
   test('should show paused hint and paused footer when paused', async ({ page }) => {

--- a/tests/e2e/pages/pip-window-content.spec.ts
+++ b/tests/e2e/pages/pip-window-content.spec.ts
@@ -55,7 +55,6 @@ test.describe('PiP Window Content and Communication', () => {
         totalDurationSeconds: 1500,
         isRunning: true,
         isStarted: true,
-        showReset: true,
         taskName: 'Test Task',
         endsAt: '10:47 AM'
       });
@@ -92,7 +91,7 @@ test.describe('PiP Window Content and Communication', () => {
     expect(checks.hasCtrlRow).toBe(false);
   });
 
-  test('should generate correct HTML for short break session', async ({ page }) => {
+  test('should generate correct HTML for short break session (paused)', async ({ page }) => {
     await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
 
     const checks = await page.evaluate(() => {
@@ -103,8 +102,8 @@ test.describe('PiP Window Content and Communication', () => {
         totalDurationSeconds: 300,
         isRunning: false,
         isStarted: true,
-        showReset: true,
-        taskName: null
+        taskName: null,
+        endsAt: '11:30 AM'
       });
       const doc = new DOMParser().parseFromString(html, 'text/html');
       return {
@@ -112,7 +111,11 @@ test.describe('PiP Window Content and Communication', () => {
         ringLabel: doc.querySelector('.ring-label')?.textContent ?? '',
         ringFill: !!doc.querySelector('.ring-fill.short-break'),
         pipCtrl: !!doc.querySelector('.pip-ctrl'),
+        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
         pipTask: !!doc.querySelector('.pip-task'),
+        pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
+        pipFooter: !!doc.querySelector('.pip-footer'),
+        footerText: doc.querySelector('.pip-footer')?.textContent ?? '',
         hasActiveTask: !!doc.querySelector('.active-task'),
       };
     });
@@ -121,7 +124,12 @@ test.describe('PiP Window Content and Communication', () => {
     expect(checks.ringLabel).toBe('SHORT BREAK');
     expect(checks.ringFill).toBe(true);
     expect(checks.pipCtrl).toBe(true);
+    expect(checks.resetBtn).toBe(true);
     expect(checks.pipTask).toBe(false);
+    expect(checks.pipHint).toBe('Space to resume');
+    expect(checks.pipFooter).toBe(true);
+    expect(checks.footerText).toContain('Paused · ends at');
+    expect(checks.footerText).toContain('11:30 AM');
     expect(checks.hasActiveTask).toBe(false);
   });
 
@@ -136,7 +144,6 @@ test.describe('PiP Window Content and Communication', () => {
         totalDurationSeconds: 900,
         isRunning: true,
         isStarted: true,
-        showReset: false,
         taskName: 'Break Task'
       });
       const doc = new DOMParser().parseFromString(html, 'text/html');
@@ -165,7 +172,6 @@ test.describe('PiP Window Content and Communication', () => {
         totalDurationSeconds: 1500,
         isRunning: true,
         isStarted: true,
-        showReset: true,
         taskName: null
       });
     });
@@ -272,6 +278,93 @@ test.describe('PiP Window Content and Communication', () => {
     expect(checks.hasActiveTask).toBe(false);
     expect(checks.hasCtrlRow).toBe(false);
     expect(checks.hasCardFooter).toBe(false);
+  });
+
+  test('should show centered play button and duration footer when not started', async ({ page }) => {
+    await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    const checks = await page.evaluate(() => {
+      const pip = (window as any).pipTimer;
+      const html = pip.generateTimerHTML({
+        sessionType: 0,
+        remainingSeconds: 1500,
+        totalDurationSeconds: 1500,
+        isRunning: false,
+        isStarted: false,
+        taskName: 'Test Task'
+      });
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return {
+        playBtn: !!doc.querySelector('.pip-play'),
+        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
+        pipFooter: !!doc.querySelector('.pip-footer'),
+        footerText: doc.querySelector('.pip-footer')?.textContent ?? '',
+        pipTask: !!doc.querySelector('.pip-task'),
+        taskName: doc.querySelector('.pip-task-name')?.textContent ?? '',
+      };
+    });
+
+    expect(checks.playBtn).toBe(true);
+    expect(checks.resetBtn).toBe(false);
+    expect(checks.pipHint).toBe('Space to start');
+    expect(checks.pipFooter).toBe(true);
+    expect(checks.footerText).toContain('25 min session');
+    expect(checks.pipTask).toBe(true);
+    expect(checks.taskName).toBe('Test Task');
+  });
+
+  test('should use monospace font for timer digits', async ({ page }) => {
+    await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    const fontFamily = await page.evaluate(() => {
+      const pip = (window as any).pipTimer;
+      const html = pip.generateTimerHTML({
+        sessionType: 0,
+        remainingSeconds: 1500,
+        totalDurationSeconds: 1500,
+        isRunning: false,
+        isStarted: false,
+        taskName: null
+      });
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const style = doc.querySelector('.ring-time');
+      return style?.getAttribute('style') ?? '';
+    });
+
+    expect(fontFamily).toContain('monospace');
+  });
+
+  test('should show paused hint and paused footer when paused', async ({ page }) => {
+    await expect(page.locator('.main-container')).toBeVisible({ timeout: 30000 });
+
+    const checks = await page.evaluate(() => {
+      const pip = (window as any).pipTimer;
+      const html = pip.generateTimerHTML({
+        sessionType: 0,
+        remainingSeconds: 750,
+        totalDurationSeconds: 1500,
+        isRunning: false,
+        isStarted: true,
+        taskName: 'Test Task',
+        endsAt: '10:47 AM'
+      });
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return {
+        playBtn: !!doc.querySelector('.pip-play'),
+        resetBtn: !!doc.querySelector('[onclick="window.pipResetTimer()"]'),
+        pipHint: doc.querySelector('.pip-hint')?.textContent ?? '',
+        pipFooter: !!doc.querySelector('.pip-footer'),
+        footerText: doc.querySelector('.pip-footer')?.textContent ?? '',
+      };
+    });
+
+    expect(checks.playBtn).toBe(true);
+    expect(checks.resetBtn).toBe(true);
+    expect(checks.pipHint).toBe('Space to resume');
+    expect(checks.pipFooter).toBe(true);
+    expect(checks.footerText).toContain('Paused · ends at');
+    expect(checks.footerText).toContain('10:47 AM');
   });
 
   test('should handle PiP toggle timer callback without error', async ({ page }) => {

--- a/tests/e2e/pages/pip-window-content.spec.ts
+++ b/tests/e2e/pages/pip-window-content.spec.ts
@@ -319,17 +319,8 @@ test.describe('PiP Window Content and Communication', () => {
 
     const hasMonospace = await page.evaluate(() => {
       const pip = (window as any).pipTimer;
-      const html = pip.generateTimerHTML({
-        sessionType: 0,
-        remainingSeconds: 1500,
-        totalDurationSeconds: 1500,
-        isRunning: false,
-        isStarted: false,
-        taskName: null
-      });
-      const doc = new DOMParser().parseFromString(html, 'text/html');
-      const styleEl = doc.querySelector('style');
-      return styleEl?.textContent?.includes('.ring-time') && styleEl?.textContent?.includes('monospace');
+      const source = pip.ensurePipStyles.toString();
+      return source.includes('monospace');
     });
 
     expect(hasMonospace).toBe(true);


### PR DESCRIPTION
Closes #74

- Per-session background colors (pomodoro red, short break green, long break blue)
- Three-state controls: not-started (play only + hint), running (pause+reset), paused (play+reset + hint)
- Monospace font on timer digits matching main page
- Increased tab/footer text sizes and contrast
- Footer shows session duration / ends-at / paused state per state
- PiP window height adjusted to 440px
- E2E test coverage for all three states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Picture-in-Picture timer with three explicit states (Not Started, Running, Paused), clearer start/resume/reset controls, contextual hints ("Space to start"/"Space to resume"), and refined footer messaging for session/ends-at status; slightly reduced PiP height.

* **Style**
  * Theme-specific visual refresh: updated tab underlines, gradients, timer ring sizing/colors, play button colors/shadows, hint/footer typography, and monospace digits.

* **Tests**
  * Expanded end-to-end coverage for not-started, running, and paused PiP states, controls, hints, footer content, and monospace styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->