### PR TITLE
fix: center play button and improve PiP timer UI consistency

### DIFF
--- a/src/Pomodoro.Web/Components/Timer/TimerControls.razor
+++ b/src/Pomodoro.Web/Components/Timer/TimerControls.razor
@@ -29,7 +29,6 @@
     else
     {
         <div class="ctrl-row">
-            <div style="width:36px"></div>
             <button class="ibtn lg @GetSessionClass()" @onclick="OnStart" disabled="@IsStartDisabled" title="@(IsStartDisabled ? "Select a task first" : "Start")" aria-label="@(IsStartDisabled ? "Select a task first" : "Start timer")">
                 @Constants.UI.PlayIcon
             </button>

--- a/src/Pomodoro.Web/Services/PipTimerService.cs
+++ b/src/Pomodoro.Web/Services/PipTimerService.cs
@@ -162,6 +162,9 @@ public class PipTimerService : IPipTimerService, ITimerEventPublisherSubscriber
             totalDurationSeconds = _timerService.Settings.GetDurationSeconds(_timerService.CurrentSessionType),
             isRunning = _timerService.IsRunning,
             isStarted = _timerService.IsStarted,
+            canStart = _timerService.CurrentSessionType == SessionType.Pomodoro
+                ? _taskService.CurrentTaskId.HasValue
+                : true,
             taskName = _timerService.CurrentSessionType == SessionType.Pomodoro
                 ? _appState.CurrentTask?.Name
                 : null,

--- a/src/Pomodoro.Web/wwwroot/js/pipTimer.js
+++ b/src/Pomodoro.Web/wwwroot/js/pipTimer.js
@@ -338,6 +338,7 @@ window.pipTimer = {
         var modeLabel = sessionType === 0 ? 'FOCUSING' : sessionType === 1 ? 'SHORT BREAK' : 'LONG BREAK';
         var isRunning = state.isRunning || false;
         var isStarted = state.isStarted || false;
+        var canStart = state.canStart !== false;
         var taskName = state.taskName || null;
         var endsAt = state.endsAt || null;
 
@@ -369,12 +370,14 @@ window.pipTimer = {
         }
 
         if (!isStarted && !isRunning) {
+            var startDisabled = sessionType === 0 && !canStart;
+            var startTitle = startDisabled ? 'Select a task first' : 'Start';
             html += '<div class="pip-ctrl">';
-            html += '<button class="pip-play ' + sessionClass + '" onclick="window.pipToggleTimer()" aria-label="Start">';
+            html += '<button class="pip-play ' + sessionClass + (startDisabled ? '" disabled' : '"') + ' onclick="window.pipToggleTimer()" aria-label="' + startTitle + '" title="' + startTitle + '">';
             html += playIcon;
             html += '</button>';
             html += '</div>';
-            html += '<div class="pip-hint">Space to start</div>';
+            html += '<div class="pip-hint">' + (startDisabled ? 'Select a task to start' : 'Space to start') + '</div>';
         } else if (isRunning) {
             html += '<div class="pip-ctrl">';
             html += '<button class="pip-reset" onclick="window.pipResetTimer()" aria-label="Reset timer">';
@@ -405,12 +408,16 @@ window.pipTimer = {
             var durationLabel = sessionType === 0 ? durationMinutes + ' min session'
                 : durationMinutes + ' min break';
             html += '<span class="lbl">' + durationLabel + '</span>';
+            html += '<span class="val"></span>';
         } else if (isRunning && endsAt) {
             html += '<span class="lbl">Ends at</span>';
             html += '<span class="val">' + endsAt + '</span>';
         } else if (isStarted && !isRunning && endsAt) {
             html += '<span class="lbl">Paused · ends at</span>';
             html += '<span class="val">' + endsAt + '</span>';
+        } else {
+            html += '<span class="lbl"></span>';
+            html += '<span class="val"></span>';
         }
         html += '</div>';
 


### PR DESCRIPTION
## Summary
- Center play button in main timer when idle (removed offset spacer from TimerControls.razor)
- Fix PiP footer "Ends at" time to always render in fixed position with consistent two-column layout
- Show "Select a task to start" hint in PiP window when pomodoro session has no task selected (disable play button)

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The Pomodoro start button is now disabled until a task is selected, with improved guidance prompting task selection.

* **Style**
  * Refined spacing in timer controls layout.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nayeem170/Pomodoro/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->