### PR TITLE
fix: collapse idle timer footer and normalize secondary typography scale

### DIFF
--- a/src/Pomodoro.Web/Pages/Index.razor
+++ b/src/Pomodoro.Web/Pages/Index.razor
@@ -62,7 +62,7 @@ else
                                OnResume="HandleTimerResume"
                                OnReset="HandleTimerReset" />
             </div>
-            <div class="card-footer">
+            <div class="card-footer @(IsTimerRunning ? "" : "idle")">
                 @if (IsTimerRunning)
                 {
                     <div class="ends-at">
@@ -70,11 +70,7 @@ else
                         <span class="val">@DateTime.Now.AddSeconds(RemainingTime.TotalSeconds).ToString("h:mm tt")</span>
                     </div>
                 }
-                else
-                {
-                    <div></div>
-                }
-                <div class="card-footer-left">
+                <div class="card-footer-actions">
                     <button class="pip-btn" @onclick="HandleTogglePip" title="@(IsPipOpen ? Constants.PipTimerUI.CloseFloatingTimerTitle : Constants.PipTimerUI.PopOutFloatingTimerTitle)" aria-label="Picture in Picture">
                         <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><rect x="1" y="1" width="12" height="12" rx="2" stroke="currentColor" stroke-width="1.2"/><rect x="7" y="7" width="5.5" height="4.5" rx="1" fill="currentColor"/></svg>
                     </button>

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -457,7 +457,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .pomo-sub {
-    font-size: 16px;
+    font-size: 11px;
     color: var(--color-text-tertiary);
 }
 
@@ -474,7 +474,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .pomo-focus-label {
-    font-size: 16px;
+    font-size: 11px;
     color: var(--color-text-tertiary);
 }
 
@@ -557,7 +557,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .task-hint {
-    font-size: 16px;
+    font-size: 13px;
     color: var(--color-text-tertiary);
     margin: 0;
 }
@@ -572,7 +572,14 @@ input, textarea, [contenteditable="true"] {
     background: var(--color-surface-light);
 }
 
-.card-footer-left {
+.card-footer.idle {
+    justify-content: flex-end;
+    border-top: none;
+    background: transparent;
+    padding: 6px 20px 14px;
+}
+
+.card-footer-actions {
     display: flex;
     align-items: center;
     gap: 5px;
@@ -639,7 +646,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .kbd {
-    font-size: 16px;
+    font-size: 11px;
     font-family: var(--font-mono);
     background: var(--color-background-primary);
     border: 0.5px solid var(--color-border-secondary);
@@ -652,7 +659,7 @@ input, textarea, [contenteditable="true"] {
     display: flex;
     align-items: center;
     gap: 4px;
-    font-size: 16px;
+    font-size: 12px;
     color: var(--color-text-tertiary);
 }
 
@@ -884,7 +891,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .completed-section h4 {
-    font-size: 16px;
+    font-size: 11px;
     color: var(--color-text-tertiary);
     margin-bottom: 8px;
     text-transform: uppercase;


### PR DESCRIPTION
## Summary
Timer-card UI cleanup (bugs confirmed against `develop`).

- **Idle footer collapse:** drop the empty `<div></div>` placeholder in `.card-footer`; add an `.idle` class (applied when `!IsTimerRunning`) that removes the border-top + background strip and right-aligns only the action buttons. No more empty blue strip when the timer is idle.
- **Class rename:** `.card-footer-left` → `.card-footer-actions` (the class held the pip/help buttons but rendered at the right edge).
- **Typography scale:** several secondary/label elements were `16px` (same as body text), flattening the hierarchy. Reduced to the existing 11px tertiary / 13px secondary scale:
  - `.task-hint` → 13px (secondary, matches `.active-task`)
  - `.kbd` → 11px, `.kbd-hint` → 12px (keycaps)
  - `.pomo-sub`, `.pomo-focus-label` → 11px (tertiary, matches `.timer-mode-label` / `.ends-at`)
  - `.completed-section h4` → 11px (uppercase micro-label)

## Verification
- `dotnet format Pomodoro.sln --verify-no-changes` — clean
- `dotnet test` — 3460/3460 passing
- E2E touchpoints unchanged: `.card-footer` container still present, `.task-hint` text unchanged

Closes #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Reduced font sizes for summary labels, focus indicators, task hints, and keyboard shortcuts for a more compact interface
  * Improved timer card footer layout and styling with refined alignment when timer is idle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->