### PR TITLE
fix(ci): fix shard_name mismatch with report link construction

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,7 @@ jobs:
           SKIPPED=$(grep -oP '\d+(?= skipped)' test-output.txt | tail -1)
           PASSED=${PASSED:-0}; FAILED=${FAILED:-0}; SKIPPED=${SKIPPED:-0}
           TOTAL=$((PASSED + FAILED + SKIPPED))
-          echo "{\"shard_name\":\"shard-${{ matrix.shardIndex }}\",\"passed\":$PASSED,\"failed\":$FAILED,\"skipped\":$SKIPPED,\"total\":$TOTAL}" > shard-summary.json
+          echo "{\"shard_name\":\"${{ matrix.shardIndex }}\",\"passed\":$PASSED,\"failed\":$FAILED,\"skipped\":$SKIPPED,\"total\":$TOTAL}" > shard-summary.json
 
       - uses: actions/upload-artifact@v4
         if: always() && inputs.upload_report


### PR DESCRIPTION
Closes #84

Resolves CodeRabbit review feedback on PR #85.

1/3 — **e2e.yml shard_name prefix mismatch** (this PR): \shard_name\ had \shard-\ prefix but \eports.yml\ constructs \2e-report-shard-\\, producing \2e-report-shard-shard-1\. Removed prefix.
2/3 — **playwright.config.ts timeout**: already fixed in commit \e04eb1\.
3/3 — **service-worker-cache.spec.ts cacheName assertion**: invalid — the published SW (\service-worker.published.js\) uses camelCase \cacheName\, matching the assertion.