### PR TITLE
fix(history): weekly time dist missing + invert Today/This week button

### DIFF
--- a/src/Pomodoro.Web/Components/History/TimeDistributionChart.razor
+++ b/src/Pomodoro.Web/Components/History/TimeDistributionChart.razor
@@ -31,7 +31,8 @@
             {
                 <div class="leg-row">
                     <div class="leg-dot" style="background:@seg.Color"></div>
-                    <span class="leg-txt">@seg.Label <span class="leg-pct">@seg.Percentage%</span></span>
+                    <span class="leg-txt" title="@seg.Label">@seg.Label</span>
+                    <span class="leg-pct" title="@seg.Percentage%">@seg.Percentage%</span>
                 </div>
             }
         </div>

--- a/src/Pomodoro.Web/Components/History/WeeklyTimeDistribution.razor
+++ b/src/Pomodoro.Web/Components/History/WeeklyTimeDistribution.razor
@@ -31,7 +31,8 @@
             {
                 <div class="leg-row">
                     <div class="leg-dot" style="background:@seg.Color"></div>
-                    <span class="leg-txt">@seg.Label <span class="leg-pct">@seg.Percentage%</span></span>
+                    <span class="leg-txt" title="@seg.Label">@seg.Label</span>
+                    <span class="leg-pct" title="@seg.Percentage%">@seg.Percentage%</span>
                 </div>
             }
         </div>

--- a/src/Pomodoro.Web/Components/History/WeeklyTimeDistribution.razor.cs
+++ b/src/Pomodoro.Web/Components/History/WeeklyTimeDistribution.razor.cs
@@ -67,7 +67,7 @@ public class WeeklyTimeDistributionBase : ComponentBase, IDisposable
     {
         var weekEnd = WeekStart.AddDays(7);
         var weekActivities = ActivityService.GetAllActivities()
-            .Where(a => a.CompletedAt.Date >= WeekStart.Date && a.CompletedAt.Date < weekEnd.Date)
+            .Where(a => a.CompletedAt.ToLocalTime().Date >= WeekStart.Date && a.CompletedAt.ToLocalTime().Date < weekEnd.Date)
             .ToList();
 
         Segments = new List<ChartSegment>();

--- a/src/Pomodoro.Web/Pages/History.razor
+++ b/src/Pomodoro.Web/Pages/History.razor
@@ -22,7 +22,7 @@ else
                         <span class="period-lbl">@FormattedSelectedDate</span>
                         <button class="nav-arr" @onclick="GoToNextDay" title="Next day" disabled="@IsSelectedDateToday" aria-label="Next day">&#8594;</button>
                     </div>
-                    <button class="nav-qbtn @(IsSelectedDateToday ? "active" : "")" @onclick="GoToToday">Today</button>
+                    <button class="nav-qbtn @(!IsSelectedDateToday ? "active" : "")" @onclick="GoToToday" disabled="@IsSelectedDateToday">Today</button>
                 </div>
             </div>
 
@@ -54,7 +54,7 @@ else
                         <span class="period-lbl">@FormattedWeekRange</span>
                         <button class="nav-arr" @onclick="GoToNextWeek" title="Next week" disabled="@IsSelectedWeekCurrent" aria-label="Next week">&#8594;</button>
                     </div>
-                    <button class="nav-qbtn @(IsSelectedWeekCurrent ? "active" : "")" @onclick="GoToThisWeek">This week</button>
+                    <button class="nav-qbtn @(!IsSelectedWeekCurrent ? "active" : "")" @onclick="GoToThisWeek" disabled="@IsSelectedWeekCurrent">This week</button>
                 </div>
             </div>
 

--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -128,10 +128,19 @@ input, textarea, [contenteditable="true"] {
     line-height: 1;
 }
 
+.header-nav a:hover {
+    background: var(--color-background-secondary);
+}
+
 .header-nav a.active {
     background: var(--color-background-secondary);
-    color: var(--color-text-primary);
+    color: var(--pomodoro-color);
     font-weight: 500;
+}
+
+.header-nav {
+    border-left: 0.5px solid var(--color-border-tertiary);
+    padding-left: 8px;
 }
 
 /* Mobile Bottom Navigation */

--- a/src/Pomodoro.Web/wwwroot/css/history.css
+++ b/src/Pomodoro.Web/wwwroot/css/history.css
@@ -417,69 +417,6 @@
     white-space: nowrap;
 }
 
-.donut-wrap {
-    position: relative;
-    width: 100%;
-    max-width: 180px;
-    aspect-ratio: 1;
-    margin: 0 auto;
-}
-
-.donut-center {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
-}
-
-.donut-val {
-    font-size: 16px;
-    font-weight: 500;
-    color: var(--color-text-primary);
-}
-
-.donut-lbl {
-    font-size: 11px;
-    color: var(--color-text-tertiary);
-}
-
-.legend {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.leg-row {
-    display: flex;
-    align-items: center;
-    gap: 3px;
-}
-
-.leg-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-.leg-txt {
-    font-size: 14px;
-    color: var(--color-text-secondary);
-    flex: 1;
-    margin-right: auto;
-}
-
-.leg-pct {
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--color-text-primary);
-    margin-left: auto;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
 .divider {
     height: 0.5px;
     background: var(--color-border-tertiary);

--- a/src/Pomodoro.Web/wwwroot/css/history.css
+++ b/src/Pomodoro.Web/wwwroot/css/history.css
@@ -75,6 +75,11 @@
     border-color: var(--color-border-primary);
 }
 
+.nav-qbtn:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
 .nav-arr:disabled {
     opacity: 0.3;
     cursor: default;

--- a/tests/Pomodoro.Web.Tests/Components/WeeklyTimeDistributionBaseTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/WeeklyTimeDistributionBaseTests.cs
@@ -126,6 +126,21 @@ public class WeeklyTimeDistributionBaseTests
     }
 
     [Fact]
+    public void CalculateSegments_UtcCompletedAt_ConvertsToLocalBeforeFiltering()
+    {
+        var weekStart = new DateTime(2026, 4, 20, 0, 0, 0, DateTimeKind.Local);
+        var activities = new List<ActivityRecord>
+        {
+            new() { Id = Guid.NewGuid(), Type = SessionType.Pomodoro, TaskName = "Task 1", CompletedAt = DateTime.SpecifyKind(new DateTime(2026, 4, 20, 0, 30, 0), DateTimeKind.Utc), DurationMinutes = 25, WasCompleted = true }
+        };
+        var sut = CreateSut(activities, weekStart);
+
+        Assert.Single(sut.Segments);
+        Assert.Equal("Task 1", sut.Segments[0].Label);
+        Assert.Equal(25, sut.TotalMinutes);
+    }
+
+    [Fact]
     public void Dispose_DoesNotThrowWhenCalledTwice()
     {
         var sut = CreateSut();

--- a/tests/e2e/pages/history-features.spec.ts
+++ b/tests/e2e/pages/history-features.spec.ts
@@ -40,8 +40,8 @@ test.describe('History Features', () => {
     const todayBtn = page.locator('button.nav-qbtn');
     await expect(todayBtn).toBeVisible();
 
-    const isActive = await todayBtn.evaluate(el => el.classList.contains('active'));
-    expect(isActive).toBe(true);
+    const isDisabled = await todayBtn.isDisabled();
+    expect(isDisabled).toBe(true);
   });
 
   test('should enable Today button after navigating away from today', async ({ page }) => {
@@ -54,13 +54,17 @@ test.describe('History Features', () => {
 
     const todayBtn = page.locator('button.nav-qbtn');
     const isActive = await todayBtn.evaluate(el => el.classList.contains('active'));
-    expect(isActive).toBe(false);
+    expect(isActive).toBe(true);
+    const isDisabled = await todayBtn.isDisabled();
+    expect(isDisabled).toBe(false);
 
     await todayBtn.click();
     await page.waitForTimeout(500);
 
     const isActiveAgain = await todayBtn.evaluate(el => el.classList.contains('active'));
-    expect(isActiveAgain).toBe(true);
+    expect(isActiveAgain).toBe(false);
+    const isDisabledAgain = await todayBtn.isDisabled();
+    expect(isDisabledAgain).toBe(true);
   });
 
   test('should disable next day button when on today', async ({ page }) => {


### PR DESCRIPTION
Closes #47

Two fixes:
1. Weekly time distribution was empty when daily view showed records.
   Root cause: CalculateSegments filtered by a.CompletedAt.Date (UTC) without
   ToLocalTime(). In UTC+6, Saturday 12:30 AM local = Friday 6:30 PM UTC,
   so .Date gave Friday, falling before the Saturday WeekStart.

2. Today/This week buttons highlighted when already on today/week (useless)
   and plain when on other dates (no affordance). Inverted: active class when
   NOT on today (clickable shortcut), disabled when on today. Added :disabled
   style for nav-qbtn matching the nav-arr pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTC to local time conversion for accurate weekly activity filtering.

* **New Features**
  * Added tooltips to chart legends displaying labels and percentages on hover.

* **UI/UX Improvements**
  * Period navigation buttons (Today/This week) now disable when the current period is selected.
  * Enhanced header navigation styling with hover effects and improved active state visibility.
  * Refined donut chart legend layout and typography.

* **Tests**
  * Added test coverage for UTC time conversion in weekly activity filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->