### PR TITLE
fix: session type header text larger than task text

### DIFF
--- a/src/Pomodoro.Web/wwwroot/css/app.css
+++ b/src/Pomodoro.Web/wwwroot/css/app.css
@@ -268,7 +268,7 @@ input, textarea, [contenteditable="true"] {
 .mode-tabs button {
     flex: 1;
     padding: 7px 0;
-    font-size: 12px;
+    font-size: 14px;
     text-align: center;
     border-radius: 7px 7px 0 0;
     border: none;
@@ -401,7 +401,7 @@ input, textarea, [contenteditable="true"] {
 }
 
 .timer-mode-label {
-    font-size: 11px;
+    font-size: 13px;
     color: var(--color-text-tertiary);
     margin-top: 5px;
     letter-spacing: .1em;

--- a/src/Pomodoro.Web/wwwroot/js/pipTimer.js
+++ b/src/Pomodoro.Web/wwwroot/js/pipTimer.js
@@ -145,7 +145,7 @@ window.pipTimer = {
                 border-radius: 7px 7px 0 0;
                 border: none;
                 background: transparent;
-                font-size: 13px;
+                font-size: 14px;
                 font-weight: 400;
                 color: rgba(255,255,255,0.3);
                 cursor: pointer;
@@ -210,7 +210,7 @@ window.pipTimer = {
             .pip-container.running.short-break-theme .ring-time { color: #27ae60; }
             .pip-container.running.long-break-theme .ring-time { color: #3498db; }
             .ring-label {
-                font-size: 12px;
+                font-size: 13px;
                 color: #8a97b8;
                 letter-spacing: .1em;
                 margin-top: 5px;


### PR DESCRIPTION
Closes #92

## Summary

Session type labels (Pomodoro, Short Break, Long Break) were smaller than task name text in both main page and PIP window.

### Changes
| Element | Before | After |
|---------|--------|-------|
| Mode tabs (desktop) | 12px | 14px |
| Timer ring label (desktop) | 11px | 13px |
| PIP tabs | 13px | 14px |
| PIP ring label | 12px | 13px |

Task text stays at 13px in both views. Session type headers are now visually prominent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Increased font sizes in mode selection buttons for better readability and visibility across the application interface
  * Improved timer mode labels with larger text sizes to enhance clarity and improve user experience
  * Enhanced Picture-in-Picture timer popup styling with larger font sizes for improved text visibility during floating timer display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->