### PR TITLE
chore: reduce codecov patch threshold to 95%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
         threshold: 0%
     patch:
       default:
-        target: 100%
+        target: 95%
         threshold: 0.5%
 parsers:
   cobertura:


### PR DESCRIPTION
Closes #96

Reduces codecov patch target from 100% to 95%.