### PR TITLE
Phase 3: Bidirectional Google Tasks sync engine

### DIFF
--- a/docs/google-tasks/phase-3-sync-engine.md
+++ b/docs/google-tasks/phase-3-sync-engine.md
@@ -7,7 +7,7 @@ Implement bidirectional sync between local IndexedDB and Google Tasks API: add w
 ## Prerequisites
 
 - Phase 2 complete (data model, sidecar, multi-list `ITaskService`) — merged PR #91
-- Phase 4 complete (read-only UI, list tabs, guards) — PR #98 pending
+- Phase 4 complete (read-only UI, list tabs, guards) — PR #98 merged
 - JS functions already exist: `googleTasks.insertTask`, `googleTasks.patchTask`, `googleTasks.deleteTask`
 - C# constants already defined: `Constants.JsInterop.GoogleTasksJsFunctions.InsertTask/PatchTask/DeleteTask`
 - `Constants.Sync.TasksScopeReadWrite` already defined

--- a/src/Pomodoro.Web/Components/Tasks/TaskItemComponent.razor
+++ b/src/Pomodoro.Web/Components/Tasks/TaskItemComponent.razor
@@ -22,7 +22,7 @@
         <span class="task-badge @Constants.Repeat.ScheduleCssClass" title="Scheduled for @Item.ScheduledDate.Value.ToString("MMM d")">@Constants.Repeat.ScheduleIcon</span>
     }
     <div class="task-actions">
-        @if (Item.IsCompleted && !Item.IsGoogleTask)
+        @if (Item.IsCompleted)
         {
             <button class="task-action-btn" @onclick="HandleUncomplete" @onclick:stopPropagation="true" title="Undo" aria-label="Undo">
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 2l6 4-6 4V2z" fill="currentColor" transform="rotate(180 6 6)"/></svg>

--- a/src/Pomodoro.Web/Components/Tasks/TaskItemComponent.razor
+++ b/src/Pomodoro.Web/Components/Tasks/TaskItemComponent.razor
@@ -4,13 +4,13 @@
 <div class="task-row @GetTaskClass()" @onclick="HandleSelect" role="button" tabindex="0" @onkeydown="HandleKeyDown">
     @if (Item.IsCompleted)
     {
-        <button class="task-checkbox completed" style="@GetCheckboxStyle()" @onclick="HandleUncomplete" @onclick:stopPropagation="true" aria-label="Undo" disabled="@Item.IsGoogleTask">
+        <button class="task-checkbox completed" style="@GetCheckboxStyle()" @onclick="HandleUncomplete" @onclick:stopPropagation="true" aria-label="Undo">
             <svg width="9" height="9" viewBox="0 0 9 9"><polyline points="1.5,4.5 3.5,6.5 7.5,2.5" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/></svg>
         </button>
     }
     else
     {
-        <button class="task-checkbox" style="@GetCheckboxStyle()" @onclick="HandleComplete" @onclick:stopPropagation="true" aria-label="Complete" disabled="@Item.IsGoogleTask"></button>
+        <button class="task-checkbox" style="@GetCheckboxStyle()" @onclick="HandleComplete" @onclick:stopPropagation="true" aria-label="Complete"></button>
     }
     <span class="task-text @(Item.IsCompleted ? "completed" : "")">@Item.Name</span>
     @if (Item.IsRecurring)
@@ -31,12 +31,9 @@
         <button class="task-action-btn" @onclick="HandleEdit" @onclick:stopPropagation="true" title="Edit" aria-label="Edit task">
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M8.5 1.5l2 2L4 10H2V8l6.5-6.5z" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
-        @if (!Item.IsGoogleTask)
-        {
-            <button class="task-action-btn delete" @onclick="HandleDelete" @onclick:stopPropagation="true" title="Delete" aria-label="Delete">
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-            </button>
-        }
+        <button class="task-action-btn delete" @onclick="HandleDelete" @onclick:stopPropagation="true" title="Delete" aria-label="Delete">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </button>
     </div>
     <span class="task-pomo-count">@FormatTime(Item.TotalFocusMinutes)</span>
 </div>

--- a/src/Pomodoro.Web/Components/Tasks/TaskListSyncStrip.razor
+++ b/src/Pomodoro.Web/Components/Tasks/TaskListSyncStrip.razor
@@ -10,7 +10,7 @@
         <span class="sync-sep">·</span>
         <span class="sync-list-name">@ListName</span>
         <span class="sync-sep">·</span>
-        <span class="sync-status">read-only</span>
+        <span class="sync-status">synced</span>
     </div>
 }
 

--- a/src/Pomodoro.Web/Models/GoogleTask.cs
+++ b/src/Pomodoro.Web/Models/GoogleTask.cs
@@ -11,4 +11,7 @@ public class GoogleTask
     public string? Parent { get; set; }
     public string? Position { get; set; }
     public string? ETag { get; set; }
+    public bool Hidden { get; set; }
 }
+
+public record GoogleTaskPatch(string? Title = null, string? Notes = null, string? Status = null, string? Due = null);

--- a/src/Pomodoro.Web/Models/TaskItem.cs
+++ b/src/Pomodoro.Web/Models/TaskItem.cs
@@ -64,6 +64,7 @@ public class TaskItem
     public string? Notes { get; set; }
     public DateTime? DueDate { get; set; }
     public Priority Priority { get; set; }
+    public bool IsLocalDirty { get; set; }
 
     public TaskItem WithUpdates(Action<TaskItem>? mutate = null)
     {
@@ -86,7 +87,8 @@ public class TaskItem
             UpdatedAt = UpdatedAt,
             Notes = Notes,
             DueDate = DueDate,
-            Priority = Priority
+            Priority = Priority,
+            IsLocalDirty = IsLocalDirty
         };
         mutate?.Invoke(copy);
         return copy;

--- a/src/Pomodoro.Web/Services/CloudSyncService.cs
+++ b/src/Pomodoro.Web/Services/CloudSyncService.cs
@@ -159,6 +159,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
             await SaveSyncStateAsync(connected: true, accessToken: token);
 
             StartPeriodicSync();
+            await _taskService.RefreshGoogleListsAsync();
             NotifyStatusChanged();
 
             var syncResult = await SyncNowAsync();
@@ -359,6 +360,8 @@ public class CloudSyncService : ICloudSyncService, IDisposable
                 await _taskService.ReloadAsync();
                 await _activityService.ReloadAsync();
             }
+
+            await _taskService.RefreshGoogleListsAsync();
 
             LastSyncedAt = remoteEnvelope.LastSyncedAt;
             await SaveSyncStateAsync();

--- a/src/Pomodoro.Web/Services/GoogleTasksService.cs
+++ b/src/Pomodoro.Web/Services/GoogleTasksService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Pomodoro.Web.Models;
@@ -117,13 +118,15 @@ public class GoogleTasksService : IGoogleTasksService
     {
         return await ExecuteWithRetryAsync(async token =>
         {
-            var body = new Dictionary<string, string?>();
+            var body = new JsonObject();
             if (updates.Title != null) body["title"] = updates.Title;
             if (updates.Notes != null) body["notes"] = updates.Notes;
             if (updates.Status != null) body["status"] = updates.Status;
             if (updates.Due != null) body["due"] = updates.Due;
 
-            var json = await _jsRuntime.InvokeAsync<string>(Constants.GoogleTasksJsFunctions.PatchTask, token, listId, taskId, body, etag);
+            var filteredJson = body.ToJsonString();
+
+            var json = await _jsRuntime.InvokeAsync<string>(Constants.GoogleTasksJsFunctions.PatchTask, token, listId, taskId, filteredJson, etag);
             var data = JsonSerializer.Deserialize<JsonElement>(json);
             var patched = MapGoogleTask(data);
             _logger.LogInformation("Patched Google task {TaskId}", taskId);
@@ -140,55 +143,12 @@ public class GoogleTasksService : IGoogleTasksService
         });
     }
 
-    private async Task ExecuteVoidWithRetryAsync(Func<string, Task> action, int maxRetries = 3)
-    {
-        var token = await _googleDriveService.GetAccessTokenAsync();
-        if (string.IsNullOrEmpty(token))
-            throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired);
-
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+    private Task ExecuteVoidWithRetryAsync(Func<string, Task> action, int maxRetries = 3)
+        => ExecuteWithRetryAsync(async token =>
         {
-            try
-            {
-                await action(token);
-                return;
-            }
-            catch (JSException ex) when (ex.Message.Contains("401"))
-            {
-                _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
-                throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
-            }
-            catch (JSException ex) when (ex.Message.Contains("403"))
-            {
-                _logger.LogWarning(ex, Constants.SyncMessages.LogTasksForbidden);
-                throw new UnauthorizedAccessException(Constants.SyncMessages.TasksAccessForbidden, ex);
-            }
-            catch (JSException ex) when (ex.Message.Contains("429"))
-            {
-                if (attempt < maxRetries - 1)
-                {
-                    var delay = (int)Math.Pow(2, attempt) * 1000;
-                    _logger.LogWarning(Constants.SyncMessages.LogTasksRateLimited);
-                    await Task.Delay(delay);
-                    token = await _googleDriveService.GetAccessTokenAsync();
-                    if (string.IsNullOrEmpty(token))
-                        throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired);
-                }
-                else
-                {
-                    _logger.LogWarning(Constants.SyncMessages.LogTasksRateLimited);
-                    throw new UnauthorizedAccessException(Constants.SyncMessages.TasksRateLimitExceeded, ex);
-                }
-            }
-            catch (JSException ex)
-            {
-                _logger.LogError(ex, Constants.SyncMessages.LogTasksApiError, ex.Message);
-                throw;
-            }
-        }
-
-        throw new UnauthorizedAccessException(Constants.SyncMessages.TasksUnavailable);
-    }
+            await action(token);
+            return true;
+        }, maxRetries);
 
     private async Task<T> ExecuteWithRetryAsync<T>(Func<string, Task<T>> action, int maxRetries = 3)
     {

--- a/src/Pomodoro.Web/Services/GoogleTasksService.cs
+++ b/src/Pomodoro.Web/Services/GoogleTasksService.cs
@@ -81,6 +81,10 @@ public class GoogleTasksService : IGoogleTasksService
         if (item.TryGetProperty("etag", out var etagProp) && etagProp.ValueKind != JsonValueKind.Null)
             etag = etagProp.GetString();
 
+        bool hidden = false;
+        if (item.TryGetProperty("hidden", out var hiddenProp) && hiddenProp.ValueKind != JsonValueKind.Null)
+            hidden = hiddenProp.GetBoolean();
+
         return new GoogleTask
         {
             Id = item.GetProperty("id").GetString() ?? string.Empty,
@@ -91,8 +95,99 @@ public class GoogleTasksService : IGoogleTasksService
             Updated = item.GetProperty("updated").GetString() ?? string.Empty,
             Parent = parent,
             Position = position,
-            ETag = etag
+            ETag = etag,
+            Hidden = hidden
         };
+    }
+
+    public async Task<GoogleTask> InsertTaskAsync(string listId, GoogleTask task)
+    {
+        return await ExecuteWithRetryAsync(async token =>
+        {
+            var body = new { title = task.Title, notes = task.Notes, due = task.Due };
+            var json = await _jsRuntime.InvokeAsync<string>(Constants.GoogleTasksJsFunctions.InsertTask, token, listId, body);
+            var data = JsonSerializer.Deserialize<JsonElement>(json);
+            var inserted = MapGoogleTask(data);
+            _logger.LogInformation("Inserted Google task {TaskId} in list {ListId}", inserted.Id, listId);
+            return inserted;
+        });
+    }
+
+    public async Task<GoogleTask?> PatchTaskAsync(string listId, string taskId, GoogleTaskPatch updates, string? etag = null)
+    {
+        return await ExecuteWithRetryAsync(async token =>
+        {
+            var body = new Dictionary<string, string?>();
+            if (updates.Title != null) body["title"] = updates.Title;
+            if (updates.Notes != null) body["notes"] = updates.Notes;
+            if (updates.Status != null) body["status"] = updates.Status;
+            if (updates.Due != null) body["due"] = updates.Due;
+
+            var json = await _jsRuntime.InvokeAsync<string>(Constants.GoogleTasksJsFunctions.PatchTask, token, listId, taskId, body, etag);
+            var data = JsonSerializer.Deserialize<JsonElement>(json);
+            var patched = MapGoogleTask(data);
+            _logger.LogInformation("Patched Google task {TaskId}", taskId);
+            return patched;
+        });
+    }
+
+    public async Task DeleteTaskAsync(string listId, string taskId)
+    {
+        await ExecuteVoidWithRetryAsync(async token =>
+        {
+            await _jsRuntime.InvokeVoidAsync(Constants.GoogleTasksJsFunctions.DeleteTask, token, listId, taskId);
+            _logger.LogInformation("Deleted Google task {TaskId} from list {ListId}", taskId, listId);
+        });
+    }
+
+    private async Task ExecuteVoidWithRetryAsync(Func<string, Task> action, int maxRetries = 3)
+    {
+        var token = await _googleDriveService.GetAccessTokenAsync();
+        if (string.IsNullOrEmpty(token))
+            throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired);
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
+        {
+            try
+            {
+                await action(token);
+                return;
+            }
+            catch (JSException ex) when (ex.Message.Contains("401"))
+            {
+                _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
+                throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+            }
+            catch (JSException ex) when (ex.Message.Contains("403"))
+            {
+                _logger.LogWarning(ex, Constants.SyncMessages.LogTasksForbidden);
+                throw new UnauthorizedAccessException(Constants.SyncMessages.TasksAccessForbidden, ex);
+            }
+            catch (JSException ex) when (ex.Message.Contains("429"))
+            {
+                if (attempt < maxRetries - 1)
+                {
+                    var delay = (int)Math.Pow(2, attempt) * 1000;
+                    _logger.LogWarning(Constants.SyncMessages.LogTasksRateLimited);
+                    await Task.Delay(delay);
+                    token = await _googleDriveService.GetAccessTokenAsync();
+                    if (string.IsNullOrEmpty(token))
+                        throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired);
+                }
+                else
+                {
+                    _logger.LogWarning(Constants.SyncMessages.LogTasksRateLimited);
+                    throw new UnauthorizedAccessException(Constants.SyncMessages.TasksRateLimitExceeded, ex);
+                }
+            }
+            catch (JSException ex)
+            {
+                _logger.LogError(ex, Constants.SyncMessages.LogTasksApiError, ex.Message);
+                throw;
+            }
+        }
+
+        throw new UnauthorizedAccessException(Constants.SyncMessages.TasksUnavailable);
     }
 
     private async Task<T> ExecuteWithRetryAsync<T>(Func<string, Task<T>> action, int maxRetries = 3)
@@ -111,6 +206,11 @@ public class GoogleTasksService : IGoogleTasksService
             {
                 _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
                 throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+            }
+            catch (JSException ex) when (ex.Message.Contains("412"))
+            {
+                _logger.LogWarning(ex, "ETag conflict on operation");
+                throw;
             }
             catch (JSException ex) when (ex.Message.Contains("403"))
             {

--- a/src/Pomodoro.Web/Services/IGoogleTasksService.cs
+++ b/src/Pomodoro.Web/Services/IGoogleTasksService.cs
@@ -7,4 +7,7 @@ public interface IGoogleTasksService
     Task<IReadOnlyList<GoogleTaskList>> GetTaskListsAsync();
     Task<IReadOnlyList<GoogleTask>> GetTasksAsync(string listId, string? updatedMin = null);
     Task<bool> IsConnectedAsync();
+    Task<GoogleTask> InsertTaskAsync(string listId, GoogleTask task);
+    Task<GoogleTask?> PatchTaskAsync(string listId, string taskId, GoogleTaskPatch updates, string? etag = null);
+    Task DeleteTaskAsync(string listId, string taskId);
 }

--- a/src/Pomodoro.Web/Services/TaskService.cs
+++ b/src/Pomodoro.Web/Services/TaskService.cs
@@ -319,7 +319,16 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                     t.Repeat.NextOccurrence = nextOccurrence;
                 });
                 NotifyStateChanged();
-                if (!existingTask.IsGoogleTask) MarkDirty();
+
+                if (existingTask.IsGoogleTask && !string.IsNullOrEmpty(existingTask.GoogleTaskId))
+                {
+                    var patch = new GoogleTaskPatch(null, null, "completed");
+                    await PushGooglePatchAsync(existingTask, patch);
+                }
+                else if (!existingTask.IsGoogleTask)
+                {
+                    MarkDirty();
+                }
                 return;
             }
         }
@@ -546,6 +555,11 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                         {
                             if (local.IsLocalDirty)
                             {
+                                if (local.IsDeleted)
+                                {
+                                    continue;
+                                }
+
                                 var localMatchesRemote =
                                     local.Name == gTask.Title &&
                                     local.IsCompleted == (gTask.Status == "completed") &&
@@ -819,11 +833,21 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                 task.GoogleListId!, task.GoogleTaskId!, patch, task.ETag);
             if (result != null)
             {
-                _appState.UpdateTask(task.Id, t =>
+                var updated = _appState.FindTaskById(task.Id);
+                if (updated != null)
                 {
-                    t.ETag = result.ETag;
-                    t.IsLocalDirty = false;
-                });
+                    var saved = updated.WithUpdates(c =>
+                    {
+                        c.ETag = result.ETag;
+                        c.IsLocalDirty = false;
+                    });
+                    await _taskRepository.SaveAsync(saved);
+                    _appState.UpdateTask(task.Id, t =>
+                    {
+                        t.ETag = saved.ETag;
+                        t.IsLocalDirty = false;
+                    });
+                }
             }
             return result;
         }
@@ -836,7 +860,13 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         catch (Exception ex) when (ex is not UnauthorizedAccessException)
         {
             _logger.LogWarning(ex, "Failed to push Google patch for task {TaskId}, marking local dirty", task.GoogleTaskId);
-            _appState.UpdateTask(task.Id, t => t.IsLocalDirty = true);
+            var dirty = _appState.FindTaskById(task.Id);
+            if (dirty != null)
+            {
+                var saved = dirty.WithUpdates(c => c.IsLocalDirty = true);
+                await _taskRepository.SaveAsync(saved);
+                _appState.UpdateTask(task.Id, t => t.IsLocalDirty = true);
+            }
             return null;
         }
     }

--- a/src/Pomodoro.Web/Services/TaskService.cs
+++ b/src/Pomodoro.Web/Services/TaskService.cs
@@ -803,7 +803,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         if (existing.IsCompleted != updated.IsCompleted)
             status = updated.IsCompleted ? "completed" : "needsAction";
         if (existing.DueDate != updated.DueDate)
-            due = updated.DueDate.HasValue ? updated.DueDate.Value.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") : null;
+            due = updated.DueDate.HasValue ? updated.DueDate.Value.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") : "";
 
         if (title == null && notes == null && status == null && due == null)
             return null;

--- a/src/Pomodoro.Web/Services/TaskService.cs
+++ b/src/Pomodoro.Web/Services/TaskService.cs
@@ -154,10 +154,43 @@ public class TaskService : ITaskService, ITimerEventSubscriber
     {
         if (!string.IsNullOrEmpty(listId) && listId != Constants.TaskLists.LocalPomodoroListId && listId != Constants.TaskLists.ScheduleListId)
         {
-            throw new NotSupportedException(Constants.Sync.TasksReadOnlyInPhase);
+            await AddGoogleTaskAsync(name, listId);
+            return;
         }
 
         await AddTaskAsync(name);
+    }
+
+    private async Task AddGoogleTaskAsync(string name, string listId)
+    {
+        var sanitized = SanitizeTaskName(name);
+        if (string.IsNullOrEmpty(sanitized) || sanitized.Length > Constants.UI.MaxTaskNameLength)
+            return;
+
+        var googleTask = new GoogleTask { Title = sanitized };
+        var inserted = await _googleTasksService.InsertTaskAsync(listId, googleTask);
+
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = inserted.Title,
+            GoogleTaskId = inserted.Id,
+            GoogleListId = listId,
+            ETag = inserted.ETag,
+            UpdatedAt = ParseGoogleDateTime(inserted.Updated),
+            Notes = inserted.Notes,
+            DueDate = ParseGoogleDate(inserted.Due),
+            IsCompleted = inserted.Status == "completed",
+            CreatedAt = DateTime.UtcNow,
+            TotalFocusMinutes = Constants.Tasks.InitialFocusMinutes,
+            PomodoroCount = Constants.Tasks.InitialPomodoroCount
+        };
+
+        await SaveTaskAsync(task);
+        _appState.InsertTask(task, Constants.Tasks.InsertAtBeginning);
+        _appState.CurrentTaskId = task.Id;
+        await SaveCurrentTaskIdAsync();
+        NotifyStateChanged();
     }
 
     public async Task UpdateTaskAsync(TaskItem task)
@@ -172,19 +205,65 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         var existingTask = _appState.FindTaskById(task.Id);
         if (existingTask == null) return;
 
-        var taskToSave = existingTask.WithUpdates(c => c.Name = name);
+        var taskToSave = existingTask.WithUpdates(c =>
+        {
+            c.Name = name;
+            c.Notes = task.Notes;
+            c.DueDate = task.DueDate;
+        });
+
+        var googlePushPatch = BuildPatch(existingTask, taskToSave);
+
         await SaveTaskAsync(taskToSave);
 
-        _appState.UpdateTask(task.Id, t => t.Name = name);
+        _appState.UpdateTask(task.Id, t =>
+        {
+            t.Name = taskToSave.Name;
+            t.Notes = taskToSave.Notes;
+            t.DueDate = taskToSave.DueDate;
+        });
+
+        if (taskToSave.IsGoogleTask && !string.IsNullOrEmpty(taskToSave.GoogleTaskId) && googlePushPatch != null)
+        {
+            var result = await PushGooglePatchAsync(taskToSave, googlePushPatch);
+            if (result != null)
+            {
+                var updatedEtag = result.ETag;
+                _appState.UpdateTask(task.Id, t => t.ETag = updatedEtag);
+                var updated = _appState.FindTaskById(task.Id);
+                if (updated != null)
+                {
+                    var withEtag = updated.WithUpdates(c => c.ETag = updatedEtag);
+                    await SaveTaskAsync(withEtag);
+                }
+            }
+        }
+        else
+        {
+            MarkDirty();
+        }
+
         NotifyStateChanged();
-        MarkDirty();
     }
 
     public async Task DeleteTaskAsync(Guid taskId)
     {
         var existingTask = _appState.FindTaskById(taskId);
         if (existingTask == null) return;
-        if (existingTask.IsGoogleTask) return;
+
+        if (existingTask.IsGoogleTask && !string.IsNullOrEmpty(existingTask.GoogleTaskId))
+        {
+            try
+            {
+                await _googleTasksService.DeleteTaskAsync(existingTask.GoogleListId!, existingTask.GoogleTaskId);
+            }
+            catch (Exception ex) when (ex is not UnauthorizedAccessException)
+            {
+                _logger.LogWarning(ex, "Failed to delete Google task {TaskId}, marking local dirty", existingTask.GoogleTaskId);
+                existingTask = existingTask.WithUpdates(c => c.IsLocalDirty = true);
+                _appState.UpdateTask(taskId, t => t.IsLocalDirty = true);
+            }
+        }
 
         var taskToSave = existingTask.WithUpdates(c =>
         {
@@ -205,15 +284,16 @@ public class TaskService : ITaskService, ITimerEventSubscriber
             await SaveCurrentTaskIdAsync();
         }
 
+        if (!existingTask.IsGoogleTask)
+            MarkDirty();
+
         NotifyStateChanged();
-        MarkDirty();
     }
 
     public async Task CompleteTaskAsync(Guid taskId)
     {
         var existingTask = _appState.FindTaskById(taskId);
         if (existingTask == null) return;
-        if (existingTask.IsGoogleTask) return;
 
         var isRecurring = existingTask.IsRecurring && existingTask.Repeat is { IsActive: true };
 
@@ -239,7 +319,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                     t.Repeat.NextOccurrence = nextOccurrence;
                 });
                 NotifyStateChanged();
-                MarkDirty();
+                if (!existingTask.IsGoogleTask) MarkDirty();
                 return;
             }
         }
@@ -249,21 +329,38 @@ public class TaskService : ITaskService, ITimerEventSubscriber
 
         _appState.UpdateTask(taskId, t => t.IsCompleted = true);
         NotifyStateChanged();
-        MarkDirty();
+
+        if (existingTask.IsGoogleTask && !string.IsNullOrEmpty(existingTask.GoogleTaskId))
+        {
+            var patch = new GoogleTaskPatch(null, null, "completed");
+            await PushGooglePatchAsync(existingTask, patch);
+        }
+        else
+        {
+            MarkDirty();
+        }
     }
 
     public async Task UncompleteTaskAsync(Guid taskId)
     {
         var existingTask = _appState.FindTaskById(taskId);
         if (existingTask == null) return;
-        if (existingTask.IsGoogleTask) return;
 
         var taskToSave = existingTask.WithUpdates(c => c.IsCompleted = false);
         await SaveTaskAsync(taskToSave);
 
         _appState.UpdateTask(taskId, t => t.IsCompleted = false);
         NotifyStateChanged();
-        MarkDirty();
+
+        if (existingTask.IsGoogleTask && !string.IsNullOrEmpty(existingTask.GoogleTaskId))
+        {
+            var patch = new GoogleTaskPatch(null, null, "needsAction");
+            await PushGooglePatchAsync(existingTask, patch);
+        }
+        else
+        {
+            MarkDirty();
+        }
     }
 
     public async Task SelectTaskAsync(Guid taskId)
@@ -422,35 +519,84 @@ public class TaskService : ITaskService, ITimerEventSubscriber
 
                     foreach (var gTask in googleTasks)
                     {
+                        if (gTask.Hidden && gTask.Status == "completed")
+                        {
+                            var hiddenLocal = existingInList.FirstOrDefault(t => t.GoogleTaskId == gTask.Id)
+                                ?? _appState.Tasks.FirstOrDefault(t => t.GoogleTaskId == gTask.Id);
+                            if (hiddenLocal != null && !hiddenLocal.IsDeleted)
+                            {
+                                var deleted = hiddenLocal.WithUpdates(c =>
+                                {
+                                    c.IsDeleted = true;
+                                    c.DeletedAt = DateTime.UtcNow;
+                                });
+                                await _taskRepository.SaveAsync(deleted);
+                                _appState.UpdateTask(hiddenLocal.Id, t =>
+                                {
+                                    t.IsDeleted = true;
+                                    t.DeletedAt = DateTime.UtcNow;
+                                });
+                            }
+                            continue;
+                        }
+
                         var local = existingInList.FirstOrDefault(t => t.GoogleTaskId == gTask.Id)
                             ?? _appState.Tasks.FirstOrDefault(t => t.GoogleTaskId == gTask.Id);
                         if (local != null)
                         {
-                            var updated = local.WithUpdates(c =>
+                            if (local.IsLocalDirty)
                             {
-                                c.Name = gTask.Title;
-                                c.IsCompleted = gTask.Status == "completed";
-                                c.Notes = gTask.Notes;
-                                c.DueDate = ParseGoogleDate(gTask.Due);
-                                c.ETag = gTask.ETag;
-                                c.UpdatedAt = ParseGoogleDateTime(gTask.Updated);
-                                c.GoogleListId = gList.Id;
-                                c.IsDeleted = false;
-                                c.DeletedAt = null;
-                            });
-                            await _taskRepository.SaveAsync(updated);
-                            _appState.UpdateTask(local.Id, t =>
+                                var localMatchesRemote =
+                                    local.Name == gTask.Title &&
+                                    local.IsCompleted == (gTask.Status == "completed") &&
+                                    (local.Notes ?? "") == (gTask.Notes ?? "") &&
+                                    local.DueDate == ParseGoogleDate(gTask.Due);
+
+                                if (localMatchesRemote)
+                                {
+                                    var cleared = local.WithUpdates(c =>
+                                    {
+                                        c.ETag = gTask.ETag;
+                                        c.UpdatedAt = ParseGoogleDateTime(gTask.Updated);
+                                        c.IsLocalDirty = false;
+                                    });
+                                    await _taskRepository.SaveAsync(cleared);
+                                    _appState.UpdateTask(local.Id, t =>
+                                    {
+                                        t.ETag = cleared.ETag;
+                                        t.UpdatedAt = cleared.UpdatedAt;
+                                        t.IsLocalDirty = false;
+                                    });
+                                }
+                            }
+                            else
                             {
-                                t.Name = updated.Name;
-                                t.IsCompleted = updated.IsCompleted;
-                                t.Notes = updated.Notes;
-                                t.DueDate = updated.DueDate;
-                                t.ETag = updated.ETag;
-                                t.UpdatedAt = updated.UpdatedAt;
-                                t.GoogleListId = updated.GoogleListId;
-                                t.IsDeleted = false;
-                                t.DeletedAt = null;
-                            });
+                                var updated = local.WithUpdates(c =>
+                                {
+                                    c.Name = gTask.Title;
+                                    c.IsCompleted = gTask.Status == "completed";
+                                    c.Notes = gTask.Notes;
+                                    c.DueDate = ParseGoogleDate(gTask.Due);
+                                    c.ETag = gTask.ETag;
+                                    c.UpdatedAt = ParseGoogleDateTime(gTask.Updated);
+                                    c.GoogleListId = gList.Id;
+                                    c.IsDeleted = false;
+                                    c.DeletedAt = null;
+                                });
+                                await _taskRepository.SaveAsync(updated);
+                                _appState.UpdateTask(local.Id, t =>
+                                {
+                                    t.Name = updated.Name;
+                                    t.IsCompleted = updated.IsCompleted;
+                                    t.Notes = updated.Notes;
+                                    t.DueDate = updated.DueDate;
+                                    t.ETag = updated.ETag;
+                                    t.UpdatedAt = updated.UpdatedAt;
+                                    t.GoogleListId = updated.GoogleListId;
+                                    t.IsDeleted = false;
+                                    t.DeletedAt = null;
+                                });
+                            }
                         }
                         else
                         {
@@ -643,6 +789,56 @@ public class TaskService : ITaskService, ITimerEventSubscriber
     {
         _cloudSyncService ??= _serviceProvider.GetService<ICloudSyncService>();
         _cloudSyncService?.ScheduleSyncAsync();
+    }
+
+    private static GoogleTaskPatch? BuildPatch(TaskItem existing, TaskItem updated)
+    {
+        string? title = null;
+        string? notes = null;
+        string? status = null;
+        string? due = null;
+
+        if (existing.Name != updated.Name) title = updated.Name;
+        if (existing.Notes != updated.Notes) notes = updated.Notes ?? "";
+        if (existing.IsCompleted != updated.IsCompleted)
+            status = updated.IsCompleted ? "completed" : "needsAction";
+        if (existing.DueDate != updated.DueDate)
+            due = updated.DueDate.HasValue ? updated.DueDate.Value.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") : null;
+
+        if (title == null && notes == null && status == null && due == null)
+            return null;
+
+        return new GoogleTaskPatch(title, notes, status, due);
+    }
+
+    private async Task<GoogleTask?> PushGooglePatchAsync(TaskItem task, GoogleTaskPatch patch)
+    {
+        try
+        {
+            var result = await _googleTasksService.PatchTaskAsync(
+                task.GoogleListId!, task.GoogleTaskId!, patch, task.ETag);
+            if (result != null)
+            {
+                _appState.UpdateTask(task.Id, t =>
+                {
+                    t.ETag = result.ETag;
+                    t.IsLocalDirty = false;
+                });
+            }
+            return result;
+        }
+        catch (Exception ex) when (ex.Message.Contains("412") && task.ETag != null)
+        {
+            _logger.LogWarning("ETag conflict on task {TaskId}, pulling to reconcile", task.GoogleTaskId);
+            await RefreshGoogleListsAsync();
+            return null;
+        }
+        catch (Exception ex) when (ex is not UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to push Google patch for task {TaskId}, marking local dirty", task.GoogleTaskId);
+            _appState.UpdateTask(task.Id, t => t.IsLocalDirty = true);
+            return null;
+        }
     }
 
     private static string SanitizeTaskName(string name)

--- a/src/Pomodoro.Web/wwwroot/js/googleDrive.js
+++ b/src/Pomodoro.Web/wwwroot/js/googleDrive.js
@@ -29,7 +29,7 @@ window.googleDrive = {
             this._clientId = clientId;
             this._tokenClient = google.accounts.oauth2.initTokenClient({
                 client_id: clientId,
-                scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/tasks.readonly openid email',
+                scope: 'https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/tasks openid email',
                 callback: (response) => {
                     if (response.access_token) {
                         this._accessToken = response.access_token;

--- a/src/Pomodoro.Web/wwwroot/js/googleTasks.js
+++ b/src/Pomodoro.Web/wwwroot/js/googleTasks.js
@@ -44,16 +44,19 @@ window.googleTasks = {
             .then(function(data) { return JSON.stringify(data); });
     },
 
-    patchTask: function(accessToken, listId, taskId, updates) {
+    patchTask: function(accessToken, listId, taskId, updates, etag) {
+        var headers = this._getAuthHeaders(accessToken);
+        if (etag) headers['If-Match'] = etag;
         var url = this._getBaseUrl() + '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(taskId);
         return fetch(url, {
             method: 'PATCH',
-            headers: this._getAuthHeaders(accessToken),
+            headers: headers,
             body: JSON.stringify(updates)
         })
             .then(function(response) {
                 if (response.ok) return response.json();
                 if (response.status === 404) throw new Error('404 Not Found');
+                if (response.status === 412) throw new Error('412 ETag mismatch');
                 throw new Error('Failed to patch task: ' + response.status);
             })
             .then(function(data) { return JSON.stringify(data); });
@@ -66,7 +69,8 @@ window.googleTasks = {
             headers: this._getAuthHeaders(accessToken)
         })
             .then(function(response) {
-                if (!response.ok) throw new Error('Failed to delete task: ' + response.status);
+                if (response.ok || response.status === 404) return;
+                throw new Error('Failed to delete task: ' + response.status);
             });
     },
 

--- a/tests/Pomodoro.Web.Tests/Components/TaskListTabsTests.cs
+++ b/tests/Pomodoro.Web.Tests/Components/TaskListTabsTests.cs
@@ -294,7 +294,7 @@ public class TaskListSyncStripTests : TestContext
 
         Assert.Contains("Google Tasks", cut.Markup);
         Assert.Contains("My Google List", cut.Markup);
-        Assert.Contains("read-only", cut.Markup);
+        Assert.Contains("synced", cut.Markup);
     }
 
     [Fact]
@@ -315,6 +315,6 @@ public class TaskListSyncStripTests : TestContext
             .Add(p => p.ListName, null));
 
         Assert.Contains("Google Tasks", cut.Markup);
-        Assert.Contains("read-only", cut.Markup);
+        Assert.Contains("synced", cut.Markup);
     }
 }

--- a/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
@@ -393,7 +393,6 @@ public class GoogleTasksServiceTests
                     throw new InvalidOperationException("Expected void result");
             }
 
-            _callIndex++;
             return default(ValueTask);
         }
 

--- a/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
@@ -214,16 +214,141 @@ public class GoogleTasksServiceTests
         Assert.Equal("00000001", tasks[0].Position);
     }
 
+    [Fact]
+    public async Task InsertTaskAsync_ReturnsInsertedTask()
+    {
+        var responseJson = JsonSerializer.Serialize(new { id = "gt-1", title = "New Task", status = "needsAction", updated = "2026-01-01T00:00:00Z", etag = "etag-new" });
+        _jsRuntime.QueueResult(responseJson);
+
+        var result = await _service.InsertTaskAsync("list-1", new GoogleTask { Title = "New Task" });
+
+        Assert.Equal("gt-1", result.Id);
+        Assert.Equal("New Task", result.Title);
+        Assert.Equal("etag-new", result.ETag);
+        Assert.Equal("googleTasks.insertTask", _jsRuntime.LastMethod);
+    }
+
+    [Fact]
+    public async Task PatchTaskAsync_ReturnsPatchedTask()
+    {
+        var responseJson = JsonSerializer.Serialize(new { id = "gt-1", title = "Updated", status = "completed", updated = "2026-01-01T00:00:00Z", etag = "etag-updated" });
+        _jsRuntime.QueueResult(responseJson);
+
+        var result = await _service.PatchTaskAsync("list-1", "gt-1", new GoogleTaskPatch("Updated", null, "completed"));
+
+        Assert.Equal("gt-1", result!.Id);
+        Assert.Equal("etag-updated", result.ETag);
+        Assert.Equal("googleTasks.patchTask", _jsRuntime.LastMethod);
+    }
+
+    [Fact]
+    public async Task PatchTaskAsync_PassesEtag()
+    {
+        var responseJson = JsonSerializer.Serialize(new { id = "gt-1", title = "X", status = "needsAction", updated = "2026-01-01T00:00:00Z" });
+        _jsRuntime.QueueResult(responseJson);
+
+        await _service.PatchTaskAsync("list-1", "gt-1", new GoogleTaskPatch("X"), "etag-abc");
+
+        Assert.Equal("etag-abc", _jsRuntime.LastArgs?[4]);
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_InvokesDeleteAndReturns()
+    {
+        _jsRuntime.QueueVoidResult();
+
+        await _service.DeleteTaskAsync("list-1", "gt-1");
+
+        Assert.Equal("googleTasks.deleteTask", _jsRuntime.LastMethod);
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_ThrowsUnauthorized_On401()
+    {
+        _jsRuntime.QueueVoidException(new JSException("Error 401: Unauthorized"));
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _service.DeleteTaskAsync("list-1", "gt-1"));
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_Retries_On429()
+    {
+        _jsRuntime.QueueVoidException(new JSException("Error 429: Too Many Requests"));
+        _jsRuntime.QueueVoidResult();
+
+        await _service.DeleteTaskAsync("list-1", "gt-1");
+
+        Assert.Equal("googleTasks.deleteTask", _jsRuntime.LastMethod);
+    }
+
+    [Fact]
+    public async Task InsertTaskAsync_ThrowsUnauthorized_On401()
+    {
+        _jsRuntime.QueueException(new JSException("Error 401: Unauthorized"));
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _service.InsertTaskAsync("list-1", new GoogleTask { Title = "T" }));
+    }
+
+    [Fact]
+    public async Task InsertTaskAsync_Retries_On429()
+    {
+        _jsRuntime.QueueException(new JSException("Error 429: Too Many Requests"));
+        var responseJson = JsonSerializer.Serialize(new { id = "gt-1", title = "Retry", status = "needsAction", updated = "2026-01-01T00:00:00Z" });
+        _jsRuntime.QueueResult(responseJson);
+
+        var result = await _service.InsertTaskAsync("list-1", new GoogleTask { Title = "Retry" });
+
+        Assert.Equal("gt-1", result.Id);
+    }
+
+    [Fact]
+    public async Task PatchTaskAsync_Throws_On412Conflict()
+    {
+        _jsRuntime.QueueException(new JSException("Error 412 ETag mismatch"));
+
+        var ex = await Assert.ThrowsAsync<JSException>(() =>
+            _service.PatchTaskAsync("list-1", "gt-1", new GoogleTaskPatch("X")));
+    }
+
+    [Fact]
+    public async Task PatchTaskAsync_Retries_On429()
+    {
+        _jsRuntime.QueueException(new JSException("Error 429: Too Many Requests"));
+        var responseJson = JsonSerializer.Serialize(new { id = "gt-1", title = "Retry", status = "needsAction", updated = "2026-01-01T00:00:00Z", etag = "etag-new" });
+        _jsRuntime.QueueResult(responseJson);
+
+        var result = await _service.PatchTaskAsync("list-1", "gt-1", new GoogleTaskPatch("Retry"));
+
+        Assert.Equal("etag-new", result!.ETag);
+    }
+
+    [Fact]
+    public async Task GetTasksAsync_ParsesHiddenProperty()
+    {
+        var responseJson = JsonSerializer.Serialize(new object[]
+        {
+            new { id = "task-1", title = "Hidden task", status = "completed", updated = "2026-01-01T00:00:00Z", hidden = true }
+        });
+        _jsRuntime.QueueResult(responseJson);
+
+        var tasks = await _service.GetTasksAsync("list-1");
+
+        Assert.Single(tasks);
+        Assert.True(tasks[0].Hidden);
+    }
+
     private class TestJsRuntime : IJSRuntime
     {
         private int _callIndex;
-        private readonly List<(object? Result, Exception? Exception)> _queue = new();
+        private readonly List<(object? Result, Exception? Exception, bool IsVoid)> _queue = new();
 
         public string? LastMethod { get; private set; }
         public object?[]? LastArgs { get; private set; }
 
-        public void QueueResult(object? result) => _queue.Add((result, null));
-        public void QueueException(Exception ex) => _queue.Add((null, ex));
+        public void QueueResult(object? result) => _queue.Add((result, null, false));
+        public void QueueException(Exception ex) => _queue.Add((null, ex, false));
+        public void QueueVoidResult() => _queue.Add((null, null, true));
+        public void QueueVoidException(Exception ex) => _queue.Add((null, ex, true));
 
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
         {
@@ -251,6 +376,30 @@ public class GoogleTasksServiceTests
         public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken)
         {
             return InvokeAsync<TValue>(identifier, (object?[]?)null);
+        }
+
+        public ValueTask InvokeVoidAsync(string identifier, object?[]? args)
+        {
+            LastMethod = identifier;
+            LastArgs = args;
+
+            if (_callIndex < _queue.Count)
+            {
+                var entry = _queue[_callIndex];
+                _callIndex++;
+                if (entry.Exception != null)
+                    throw entry.Exception;
+                if (!entry.IsVoid)
+                    throw new InvalidOperationException("Expected void result");
+            }
+
+            _callIndex++;
+            return default(ValueTask);
+        }
+
+        public ValueTask InvokeVoidAsync(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            return InvokeVoidAsync(identifier, args);
         }
 
         public void Dispose() { }

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
@@ -173,7 +173,11 @@ public class TaskServiceMultiListTests
         await sut.AddTaskAsync("task name", "google-list-id");
 
         _mockGoogleTasksService.Verify(x => x.InsertTaskAsync("google-list-id", It.IsAny<GoogleTask>()), Times.Once);
-        _appState.Tasks.Should().Contain(t => t.GoogleTaskId == "gt-1" && t.Name == "task name");
+        _appState.Tasks.Should().Contain(t =>
+            t.GoogleTaskId == "gt-1" &&
+            t.GoogleListId == "google-list-id" &&
+            t.Name == "task name" &&
+            t.ETag == "etag-1");
     }
 
     [Fact]
@@ -900,7 +904,7 @@ public class TaskServiceMultiListTests
         await sut.UpdateTaskAsync(task.WithUpdates(c => c.Name = "New Name"));
 
         _mockGoogleTasksService.Verify(x => x.PatchTaskAsync("glist-1", "gtask-1",
-            It.Is<GoogleTaskPatch>(p => p.Title == "New Name"), It.IsAny<string?>()), Times.Once);
+            It.Is<GoogleTaskPatch>(p => p.Title == "New Name"), "etag-1"), Times.Once);
         _appState.FindTaskById(task.Id)!.Name.Should().Be("New Name");
         _appState.FindTaskById(task.Id)!.ETag.Should().Be("etag-2");
     }

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
@@ -162,13 +162,18 @@ public class TaskServiceMultiListTests
     }
 
     [Fact]
-    public async Task AddTaskAsync_GoogleList_ThrowsNotSupportedException()
+    public async Task AddTaskAsync_GoogleList_InsertsViaGoogleTasksService()
     {
+        var inserted = new GoogleTask { Id = "gt-1", Title = "task name", ETag = "etag-1", Updated = "2024-01-01T00:00:00Z" };
+        _mockGoogleTasksService.Setup(x => x.InsertTaskAsync("google-list-id", It.IsAny<GoogleTask>()))
+            .ReturnsAsync(inserted);
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+
         var sut = CreateSut();
+        await sut.AddTaskAsync("task name", "google-list-id");
 
-        var act = () => sut.AddTaskAsync("task name", "google-list-id");
-
-        await act.Should().ThrowAsync<NotSupportedException>();
+        _mockGoogleTasksService.Verify(x => x.InsertTaskAsync("google-list-id", It.IsAny<GoogleTask>()), Times.Once);
+        _appState.Tasks.Should().Contain(t => t.GoogleTaskId == "gt-1" && t.Name == "task name");
     }
 
     [Fact]
@@ -666,7 +671,7 @@ public class TaskServiceMultiListTests
     }
 
     [Fact]
-    public async Task CompleteTaskAsync_GoogleTask_IsNoOp()
+    public async Task CompleteTaskAsync_GoogleTask_PushesPatchAndSavesLocally()
     {
         var task = new TaskItem
         {
@@ -678,16 +683,19 @@ public class TaskServiceMultiListTests
         };
         _appState.Tasks = [task];
         _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ReturnsAsync((GoogleTask?)null);
 
         var sut = CreateSut();
         await sut.CompleteTaskAsync(task.Id);
 
-        _mockTaskRepo.Verify(x => x.SaveAsync(It.IsAny<TaskItem>()), Times.Never);
-        _appState.FindTaskById(task.Id)!.IsCompleted.Should().BeFalse();
+        _mockTaskRepo.Verify(x => x.SaveAsync(It.Is<TaskItem>(t => t.IsCompleted)), Times.Once);
+        _mockGoogleTasksService.Verify(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()), Times.Once);
+        _appState.FindTaskById(task.Id)!.IsCompleted.Should().BeTrue();
     }
 
     [Fact]
-    public async Task UncompleteTaskAsync_GoogleTask_IsNoOp()
+    public async Task UncompleteTaskAsync_GoogleTask_PushesPatchAndSavesLocally()
     {
         var task = new TaskItem
         {
@@ -700,16 +708,19 @@ public class TaskServiceMultiListTests
         };
         _appState.Tasks = [task];
         _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ReturnsAsync((GoogleTask?)null);
 
         var sut = CreateSut();
         await sut.UncompleteTaskAsync(task.Id);
 
-        _mockTaskRepo.Verify(x => x.SaveAsync(It.IsAny<TaskItem>()), Times.Never);
-        _appState.FindTaskById(task.Id)!.IsCompleted.Should().BeTrue();
+        _mockTaskRepo.Verify(x => x.SaveAsync(It.Is<TaskItem>(t => !t.IsCompleted)), Times.Once);
+        _mockGoogleTasksService.Verify(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()), Times.Once);
+        _appState.FindTaskById(task.Id)!.IsCompleted.Should().BeFalse();
     }
 
     [Fact]
-    public async Task DeleteTaskAsync_GoogleTask_IsNoOp()
+    public async Task DeleteTaskAsync_GoogleTask_DeletesViaGoogleAndSoftDeletesLocally()
     {
         var task = new TaskItem
         {
@@ -720,13 +731,16 @@ public class TaskServiceMultiListTests
             CreatedAt = DateTime.UtcNow
         };
         _appState.Tasks = [task];
+        _appState.CurrentTaskId = task.Id;
         _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.DeleteTaskAsync("glist-1", "gtask-1")).Returns(Task.CompletedTask);
 
         var sut = CreateSut();
         await sut.DeleteTaskAsync(task.Id);
 
-        _mockTaskRepo.Verify(x => x.SaveAsync(It.IsAny<TaskItem>()), Times.Never);
-        _appState.FindTaskById(task.Id)!.IsDeleted.Should().BeFalse();
+        _mockGoogleTasksService.Verify(x => x.DeleteTaskAsync("glist-1", "gtask-1"), Times.Once);
+        _mockTaskRepo.Verify(x => x.SaveAsync(It.Is<TaskItem>(t => t.IsDeleted)), Times.Once);
+        _appState.FindTaskById(task.Id)!.IsDeleted.Should().BeTrue();
     }
 
     [Fact]
@@ -861,5 +875,253 @@ public class TaskServiceMultiListTests
         await sut.GetTasksForListAsync("glist-1");
 
         _mockSidecarRepo.Verify(x => x.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_GoogleTask_PushesPatchWithChangedFields()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Old Name",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            CreatedAt = DateTime.UtcNow,
+            Notes = "old notes"
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        var patched = new GoogleTask { Id = "gtask-1", Title = "New Name", ETag = "etag-2", Updated = "2024-01-01T00:00:00Z" };
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ReturnsAsync(patched);
+
+        var sut = CreateSut();
+        await sut.UpdateTaskAsync(task.WithUpdates(c => c.Name = "New Name"));
+
+        _mockGoogleTasksService.Verify(x => x.PatchTaskAsync("glist-1", "gtask-1",
+            It.Is<GoogleTaskPatch>(p => p.Title == "New Name"), It.IsAny<string?>()), Times.Once);
+        _appState.FindTaskById(task.Id)!.Name.Should().Be("New Name");
+        _appState.FindTaskById(task.Id)!.ETag.Should().Be("etag-2");
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_LocalTask_MarksDirty()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Local Task",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        var mockCloudSync = new Mock<ICloudSyncService>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICloudSyncService))).Returns(mockCloudSync.Object);
+
+        var sut = CreateSut();
+        await sut.UpdateTaskAsync(task.WithUpdates(c => c.Name = "Updated"));
+
+        mockCloudSync.Verify(x => x.ScheduleSyncAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_GoogleTask_DoesNotMarkDirty()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ReturnsAsync((GoogleTask?)null);
+        var mockCloudSync = new Mock<ICloudSyncService>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICloudSyncService))).Returns(mockCloudSync.Object);
+
+        var sut = CreateSut();
+        await sut.UpdateTaskAsync(task.WithUpdates(c => c.Name = "Updated"));
+
+        mockCloudSync.Verify(x => x.ScheduleSyncAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_GoogleTask_PushFailure_SetsIsLocalDirty()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ThrowsAsync(new Exception("Network error"));
+
+        var sut = CreateSut();
+        await sut.CompleteTaskAsync(task.Id);
+
+        _appState.FindTaskById(task.Id)!.IsLocalDirty.Should().BeTrue();
+        _appState.FindTaskById(task.Id)!.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_GoogleTask_PushFailure_MarksDirtyAndStillSoftDeletes()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.DeleteTaskAsync("glist-1", "gtask-1"))
+            .ThrowsAsync(new Exception("Network error"));
+
+        var sut = CreateSut();
+        await sut.DeleteTaskAsync(task.Id);
+
+        _mockGoogleTasksService.Verify(x => x.DeleteTaskAsync("glist-1", "gtask-1"), Times.Once);
+        _appState.FindTaskById(task.Id)!.IsDeleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteTaskAsync_GoogleTask_PushFailure_MarksIsLocalDirty()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.DeleteTaskAsync("glist-1", "gtask-1"))
+            .ThrowsAsync(new Exception("Network error"));
+
+        var sut = CreateSut();
+        await sut.DeleteTaskAsync(task.Id);
+
+        _appState.FindTaskById(task.Id)!.IsLocalDirty.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RefreshGoogleListsAsync_SkipsOverwriteWhenIsLocalDirty()
+    {
+        var localTask = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Local Modified",
+            IsCompleted = true,
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            IsLocalDirty = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [localTask];
+        _mockTaskRepo.Setup(x => x.GetByGoogleListIdAsync("glist-1")).ReturnsAsync([localTask]);
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ReturnsAsync([new GoogleTaskList { Id = "glist-1", Title = "List 1" }]);
+        _mockGoogleTasksService.Setup(x => x.GetTasksAsync("glist-1", null))
+            .ReturnsAsync([new GoogleTask { Id = "gtask-1", Title = "Remote Title", Status = "needsAction", ETag = "etag-2", Updated = "2024-01-01T00:00:00Z" }]);
+
+        var sut = CreateSut();
+        await sut.RefreshGoogleListsAsync();
+
+        _appState.FindTaskById(localTask.Id)!.Name.Should().Be("Local Modified");
+        _appState.FindTaskById(localTask.Id)!.IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RefreshGoogleListsAsync_ClearsDirtyFlagWhenLocalMatchesRemote()
+    {
+        var localTask = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Matched",
+            IsCompleted = false,
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            IsLocalDirty = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [localTask];
+        _mockTaskRepo.Setup(x => x.GetByGoogleListIdAsync("glist-1")).ReturnsAsync([localTask]);
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ReturnsAsync([new GoogleTaskList { Id = "glist-1", Title = "List 1" }]);
+        _mockGoogleTasksService.Setup(x => x.GetTasksAsync("glist-1", null))
+            .ReturnsAsync([new GoogleTask { Id = "gtask-1", Title = "Matched", Status = "needsAction", ETag = "etag-2", Updated = "2024-01-01T00:00:00Z" }]);
+
+        var sut = CreateSut();
+        await sut.RefreshGoogleListsAsync();
+
+        _appState.FindTaskById(localTask.Id)!.IsLocalDirty.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RefreshGoogleListsAsync_HiddenCompletedTask_SoftDeletesLocally()
+    {
+        var localTask = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Hidden Task",
+            IsCompleted = true,
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [localTask];
+        _mockTaskRepo.Setup(x => x.GetByGoogleListIdAsync("glist-1")).ReturnsAsync([localTask]);
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ReturnsAsync([new GoogleTaskList { Id = "glist-1", Title = "List 1" }]);
+        _mockGoogleTasksService.Setup(x => x.GetTasksAsync("glist-1", null))
+            .ReturnsAsync([new GoogleTask { Id = "gtask-1", Title = "Hidden Task", Status = "completed", ETag = "etag-1", Updated = "2024-01-01T00:00:00Z", Hidden = true }]);
+
+        var sut = CreateSut();
+        await sut.RefreshGoogleListsAsync();
+
+        _appState.FindTaskById(localTask.Id)!.IsDeleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_LocalTask_MarksDirty()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Local Task",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        var mockCloudSync = new Mock<ICloudSyncService>();
+        _mockServiceProvider.Setup(x => x.GetService(typeof(ICloudSyncService))).Returns(mockCloudSync.Object);
+
+        var sut = CreateSut();
+        await sut.CompleteTaskAsync(task.Id);
+
+        mockCloudSync.Verify(x => x.ScheduleSyncAsync(), Times.Once);
     }
 }

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
@@ -1124,4 +1124,92 @@ public class TaskServiceMultiListTests
 
         mockCloudSync.Verify(x => x.ScheduleSyncAsync(), Times.Once);
     }
+
+    [Fact]
+    public async Task AddTaskAsync_GoogleList_EmptyName_ReturnsEarly()
+    {
+        var sut = CreateSut();
+
+        await sut.AddTaskAsync("", "google-list-id");
+
+        _mockGoogleTasksService.Verify(x => x.InsertTaskAsync(It.IsAny<string>(), It.IsAny<GoogleTask>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_GoogleTask_PushesDueDateClearing()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            CreatedAt = DateTime.UtcNow,
+            DueDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc)
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        var patched = new GoogleTask { Id = "gt-1", Title = "Google Task", ETag = "etag-2", Updated = "2026-01-01T00:00:00Z" };
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ReturnsAsync(patched);
+
+        var sut = CreateSut();
+        var updatedTask = task.WithUpdates(c =>
+        {
+            c.DueDate = null;
+        });
+        await sut.UpdateTaskAsync(updatedTask);
+
+        _mockGoogleTasksService.Verify(x => x.PatchTaskAsync("glist-1", "gtask-1",
+            It.Is<GoogleTaskPatch>(p => p.Due == ""),
+            It.IsAny<string?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_GoogleTask_EtagConflict_TriggersPull()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Old Name",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            ETag = "etag-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockTaskRepo.Setup(x => x.SaveAsync(It.IsAny<TaskItem>())).ReturnsAsync(true);
+        _mockTaskRepo.Setup(x => x.GetByGoogleListIdAsync("glist-1")).ReturnsAsync([task]);
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ReturnsAsync([new GoogleTaskList { Id = "glist-1", Title = "List 1" }]);
+        _mockGoogleTasksService.Setup(x => x.GetTasksAsync("glist-1", null))
+            .ReturnsAsync([new GoogleTask { Id = "gtask-1", Title = "Remote Name", Status = "needsAction", ETag = "etag-remote", Updated = "2026-01-01T00:00:00Z" }]);
+        _mockGoogleTasksService.Setup(x => x.PatchTaskAsync("glist-1", "gtask-1", It.IsAny<GoogleTaskPatch>(), It.IsAny<string?>()))
+            .ThrowsAsync(new Exception("412 ETag mismatch"));
+        _mockIndexedDb.Setup(x => x.GetAsync<GoogleTasksSettings>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((GoogleTasksSettings?)null);
+
+        var sut = CreateSut();
+        await sut.UpdateTaskAsync(task.WithUpdates(c => c.Name = "New Name"));
+
+        _mockGoogleTasksService.Verify(x => x.GetTaskListsAsync(), Times.AtLeastOnce);
+        _appState.FindTaskById(task.Id)!.Name.Should().Be("Remote Name");
+    }
+
+    [Fact]
+    public async Task UpdateListVisibilityAsync_HidingCurrentList_FallsBackToFirstVisible()
+    {
+        _appState.CurrentListId = "glist-2";
+        var sut = CreateSut();
+        SetCachedGoogleLists(sut, [
+            new GoogleListCacheEntry("glist-1", "List 1", "#4285F4", true),
+            new GoogleListCacheEntry("glist-2", "List 2", "#0B8043", true)
+        ]);
+
+        await sut.UpdateListVisibilityAsync("glist-2", false);
+
+        _appState.CurrentListId.Should().Be("glist-1");
+    }
 }


### PR DESCRIPTION
## Phase 3 — Bidirectional Google Tasks Sync Engine

Closes #99

Implement 2-way sync between local IndexedDB and Google Tasks API.

### Changes
- Widen auth scope `tasks.readonly` -> `tasks` 
- Add write methods: `InsertTaskAsync`, `PatchTaskAsync`, `DeleteTaskAsync`
- `If-Match` ETag header on `patchTask` JS with 412 conflict detection
- Direct push model: `TaskService` calls Google API at mutation time
- `IsLocalDirty` flag prevents pull from overwriting failed pushes
- `BuildPatch` helper sends only changed fields
- Dirty-flag reconciliation in `RefreshGoogleListsAsync`
- Hidden completed Google tasks auto-soft-deleted on pull
- Google pull wired into `CloudSyncService` after Drive pull + connect
- UI guards removed: checkbox/delete enabled for Google tasks
- Sync strip updated: read-only -> synced
- Idempotent deleteTask JS (404 = success)
- 11 new tests, 4 rewritten (3582 total passing)

### Plan
See `docs/google-tasks/phase-3-sync-engine.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google tasks are now fully supported for add, edit, complete, uncomplete, and delete directly in the app.
* **Bug Fixes**
  * Google list sync status now shows “synced.”
  * Hidden/completed Google tasks are reflected correctly, including soft-deletes.
  * Improved reconciliation preserves local edits and handles ETag conflicts more reliably.
  * Better concurrency handling for patch requests; delete no longer fails on missing tasks.
* **Documentation**
  * Updated sync prerequisites to reflect merged Phase 4 availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->