### PR TITLE
fix: tasks not rendering and Google sync 401 storm on startup (Fixes 1-7)

### DIFF
--- a/docs/fixes/manual-test-checklist.md
+++ b/docs/fixes/manual-test-checklist.md
@@ -18,8 +18,8 @@ Work top-to-bottom. Each case is discrete with an expected result. Mark `[ ]` �
 - [ ] **TC8 — Silent re-auth on reload (Fix 4).** While connected, close & reopen the tab. **Expected:** reconnects silently; Google lists load; no reconnect prompt; no 401 storm in console.
 - [ ] **TC9 — Reconnect banner (Fix 3).** Revoke access in your Google Account security page → reload → open Cloud Sync settings. **Expected:** "Session expired — Reconnect" banner appears; click Reconnect → re-auths → banner clears.
 - [ ] **TC10 — Sync Now.** Settings → Sync Now button. **Expected:** success; Last synced time updates.
-- [ ] **TC11 — Tasks auth failure isolates Drive (Fix 2).** With Drive connected but the Tasks token revoked, reload. **Expected:** Drive periodic sync still runs (console: one warning, not "init attempt 3 failed"); local tasks render.
-- [ ] **TC12 — 401 self-heals (Fix 1).** Let the Tasks token expire (wait or revoke). Trigger a list refresh. **Expected:** one silent re-auth, lists load — not a hard failure.
+- [ ] **TC11 — Tasks auth failure isolates Drive (Fix 2).** With Drive connected, disable the Google Tasks API in GCP (or use an account whose grant lacks the Tasks scope) so Tasks calls 403, then reload. **Expected:** Drive periodic sync still runs (console: one warning, not "init attempt 3 failed"); local tasks render.
+- [ ] **TC12 — 401 self-heals (Fix 1).** While connected, let the GIS access token expire (wait ~1h, or exercise it near expiry), then trigger a list refresh. **Expected:** one silent re-auth, lists load — not a hard failure.
 
 ## Persistence / lifecycle
 - [ ] **TC13 — Selected list survives reload.** Pick a (valid) Google list, reload. **Expected:** same list selected and its tasks render.

--- a/docs/fixes/manual-test-checklist.md
+++ b/docs/fixes/manual-test-checklist.md
@@ -1,0 +1,27 @@
+# Manual Test Checklist — Tasks-not-rendering fix set (Fixes 1–7)
+
+Work top-to-bottom. Each case is discrete with an expected result. Mark `[ ]` → `[x]` when done.
+
+## Prerequisite (do once first)
+- [ ] **TC0 — Clean bundle.** Stop server → `dotnet build` → run fresh build. DevTools → Application → Service Workers → Unregister → hard-reload (Disable cache on Network). **Expected:** app loads, no stale PWA code.
+
+## Tasks tab & list rendering (Fixes 5, 6, 7)
+- [ ] **TC1 — Add local task shows immediately.** Click "+ Add", type a name, press Enter. **Expected:** task appears in list; Tasks-tab badge count +1.
+- [ ] **TC2 — Switch Schedule → Tasks.** Click the Schedule tab, then the Tasks tab. **Expected:** local tasks render both times; no empty list.
+- [ ] **TC3 — Repeated click is stable.** Click the Tasks tab 3× rapidly. **Expected:** list stays populated, no flicker to empty.
+- [ ] **TC4 — Dead-id recovery (the R1 fix).** Connect Google Tasks → pick a Google list → Disconnect → reload → click the Tasks tab. **Expected:** local tasks render (badge = list count); click is not swallowed.
+- [ ] **TC5 — Completed tasks separate.** Complete a task. **Expected:** it moves under a "Completed" section; badge count drops by 1.
+- [ ] **TC6 — Badge = list count invariant.** With a few local tasks, compare the Tasks-tab badge number to the visible task count. **Expected:** identical.
+
+## Cloud Sync (Fixes 1, 2, 3, 4)
+- [ ] **TC7 — Connect.** Settings → Cloud Sync → Connect. **Expected:** connects; connected status; no console errors.
+- [ ] **TC8 — Silent re-auth on reload (Fix 4).** While connected, close & reopen the tab. **Expected:** reconnects silently; Google lists load; no reconnect prompt; no 401 storm in console.
+- [ ] **TC9 — Reconnect banner (Fix 3).** Revoke access in your Google Account security page → reload → open Cloud Sync settings. **Expected:** "Session expired — Reconnect" banner appears; click Reconnect → re-auths → banner clears.
+- [ ] **TC10 — Sync Now.** Settings → Sync Now button. **Expected:** success; Last synced time updates.
+- [ ] **TC11 — Tasks auth failure isolates Drive (Fix 2).** With Drive connected but the Tasks token revoked, reload. **Expected:** Drive periodic sync still runs (console: one warning, not "init attempt 3 failed"); local tasks render.
+- [ ] **TC12 — 401 self-heals (Fix 1).** Let the Tasks token expire (wait or revoke). Trigger a list refresh. **Expected:** one silent re-auth, lists load — not a hard failure.
+
+## Persistence / lifecycle
+- [ ] **TC13 — Selected list survives reload.** Pick a (valid) Google list, reload. **Expected:** same list selected and its tasks render.
+- [ ] **TC14 — Stale selected list falls back.** Select a Google list, disconnect, reload. **Expected:** app selects local Tasks list automatically; local tasks render.
+- [ ] **TC15 — Disconnect clears state.** Cloud Sync → Disconnect. **Expected:** Google tabs vanish, returns to local list, no errors.

--- a/docs/fixes/tasks-not-rendering.md
+++ b/docs/fixes/tasks-not-rendering.md
@@ -4,7 +4,7 @@
 
 On startup the console repeats, three times:
 
-```
+```text
 tasks.googleapis.com/tasks/v1/users/@me/lists  401 ()
 warn: GoogleTasksService  Sync unauthorized, reconnection required
 warn: CloudSyncService    Cloud sync init attempt N failed
@@ -22,7 +22,7 @@ Google Tasks lists never load; periodic sync never starts.
 The cause is an **expired access token that is never refreshed**, plus retry/propagation
 logic that turns a routine, recoverable expiry into a hard startup failure.
 
-```
+```text
 Persisted access token restored at CloudSyncService.cs:126 is expired (GIS tokens ~1h)
   -> GET /users/@me/lists returns 401
   -> GoogleTasksService.ExecuteWithRetryAsync (GoogleTasksService.cs:165) converts 401 ->
@@ -193,7 +193,7 @@ filter at `TaskService.cs:436`. So they cannot diverge by filtering — the only
 badge 11 / list 0 is that the rendered list was fetched for a **different list id** than the
 badge's local list.
 
-```
+```text
 Prior session selected a Google list -> _appState.CurrentListId persisted (AppStateRecord)
   -> next startup restores that Google list id (TaskService.cs:94-96)
   -> Google pull fails: 401 then 403 (scope) -> GetTaskListsAsync throws at TaskService.cs:483
@@ -236,28 +236,6 @@ private async Task EnsureCurrentListSelectableAsync()
 `SelectListAsync` persists the corrected id and fires `NotifyStateChanged`, so the home page
 re-runs `UpdateStateAsync` and renders the 11 local tasks. Build clean.
 
-**Fix 6 (the render fix) — collapse dead list ids at the render boundary**  ✅ implemented
-
-Fix 5 corrected the persisted `_appState.CurrentListId`, but the page's `ActiveListId`
-latched the dead Google id and the presenter preferred it: `Index.razor.cs` passes
-`ActiveListId` as `currentListId`, the resolver is `currentListId ?? CurrentListId ?? local`,
-and `:275` sets `ActiveListId = state.CurrentListId`. Once `ActiveListId = <dead id>` it wins
-over the corrected `CurrentListId` on every refresh → `GetTasksForListAsync(deadId)` → 0
-tasks, no throw → empty list while the badge (a live getter) still shows 11. The latch was
-sticky: even tab clicks kept preferring the latched id.
-
-Two complementary collapses break the latch:
-1. **`IndexPagePresenterService.UpdateStateAsync`** resolves the requested id against
-   `taskService.TaskLists` (always local + schedule + cached Google); a non-member id falls
-   back to local, so both the fetched tasks and the echoed `CurrentListId`/`ActiveListId`
-   revert to local.
-2. **`TaskService.GetTasksForListAsync`** (defense-in-depth) rewrites a non-local,
-   non-schedule, non-cached-Google id to local before filtering.
-
-Tests: `IndexPagePresenterServiceTests.UpdateStateAsync_DeadListId_CollapsesToLocal`,
-`TaskServiceMultiListTests.GetTasksForListAsync_DeadGoogleListId_CollapsesToLocal`. Existing
-`GetTasksForListAsync`/sidecar tests now register their Google list in `_cachedGoogleLists`.
-
 ### The 403 itself is configuration, not a code bug
 
 The scope string already requests full tasks scope
@@ -277,7 +255,7 @@ Fix 5 corrected the **persisted** `_appState.CurrentListId`, but the page still 
 empty because the **page's `ActiveListId` latched the dead Google id and overrode the
 correction**:
 
-```
+```text
 IndexPagePresenterService resolves: listId = currentListId ?? CurrentListId ?? local
 Index.razor.cs:265 passes ActiveListId as currentListId, and :275 sets ActiveListId = state.CurrentListId
   -> once ActiveListId == deadGoogleId, it WINS over the Fix 5-corrected _appState.CurrentListId

--- a/docs/fixes/tasks-not-rendering.md
+++ b/docs/fixes/tasks-not-rendering.md
@@ -1,0 +1,503 @@
+# Fix: Tasks not rendering / Google sync fails on startup (401 storm)
+
+## Symptom
+
+On startup the console repeats, three times:
+
+```
+tasks.googleapis.com/tasks/v1/users/@me/lists  401 ()
+warn: GoogleTasksService  Sync unauthorized, reconnection required
+warn: CloudSyncService    Cloud sync init attempt N failed
+System.UnauthorizedAccessException: Tasks connection lost — reconnect required
+ ---> Microsoft.JSInterop.JSException: 401 Unauthorized
+   at GoogleTasksService.GetTaskListsAsync()        GoogleTasksService.cs:26
+   at TaskService.RefreshGoogleListsAsync()         TaskService.cs:483
+   at CloudSyncService.InitializeAsync()            CloudSyncService.cs:130
+```
+
+Google Tasks lists never load; periodic sync never starts.
+
+## Confirmed root cause (runtime trace 2026-06-28) — token expiry, no silent re-auth
+
+The cause is an **expired access token that is never refreshed**, plus retry/propagation
+logic that turns a routine, recoverable expiry into a hard startup failure.
+
+```
+Persisted access token restored at CloudSyncService.cs:126 is expired (GIS tokens ~1h)
+  -> GET /users/@me/lists returns 401
+  -> GoogleTasksService.ExecuteWithRetryAsync (GoogleTasksService.cs:165) converts 401 ->
+     UnauthorizedAccessException WITHOUT calling TrySilentAuthAsync() to mint a fresh token
+  -> TaskService.RefreshGoogleListsAsync catch filter `when (ex is not UnauthorizedAccessException)`
+     (TaskService.cs:647) deliberately lets it propagate
+  -> CloudSyncService.InitializeAsync generic catch (CloudSyncService.cs:138) logs
+     "init attempt N failed" and retries 3x — each retry reuses the SAME stale token
+     (re-read from syncState.AccessToken at :126) -> 3 identical 401s
+  -> after 3 attempts init gives up; StartPeriodicSync() (CloudSyncService.cs:131) never runs
+```
+
+### Defect 1 (primary) — 401 handler never attempts silent re-auth
+
+`src/Pomodoro.Web/Services/GoogleTasksService.cs:165-168`:
+
+```csharp
+catch (JSException ex) when (ex.Message.Contains("401"))
+{
+    _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
+    throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+}
+```
+
+`GetAccessTokenAsync()` (`GoogleDriveService.cs:99`) just returns the stored token — it does
+**not** refresh. The "retry" loop in `ExecuteWithRetryAsync` only retries on `429`; on `401`
+it throws immediately. A `TrySilentAuthAsync()` path exists
+(`GoogleDriveService.cs:32`, GIS silent token flow) but is **never invoked**, so an expired
+token can never self-heal.
+
+### Defect 2 — futile retries + Tasks 401 aborts whole sync init
+
+`src/Pomodoro.Web/Services/CloudSyncService.cs:108-150`: the 3× retry loop re-reads the same
+persisted `syncState.AccessToken` each attempt, so all three attempts 401 identically. And
+because `RefreshGoogleListsAsync` (a read-only Google pull) throws on 401, the entire
+`InitializeAsync` attempt aborts — `StartPeriodicSync()` at `:131` is skipped, disabling
+**all** sync (including Drive), not just Tasks.
+
+### Why it's expiry, not a scope gap
+
+403 (insufficient scope) is handled separately at `GoogleTasksService.cs:175`. The trace is
+**401**, so the token is recognized but expired — silent re-auth will fix it. (If an existing
+Drive-only user had never consented `tasks.readonly`, that path returns 403 and needs a
+re-Connect prompt instead — see Appendix C.)
+
+## Fixes
+
+> **Status: RESOLVED.** Fix 1–7 implemented (build clean). Fix 6 (render-boundary collapse)
+> makes the empty list render the local tasks; Fix 7 (tab click compares the real
+> `CurrentListId`, not the fallback) closes the residual "click does nothing" dead-end. The
+> symptom that persisted across earlier passes was **R0 — the running process served a stale
+> pre-fix binary**; restarting the app at `:7025` after Fix 7 fixed it (see "RESOLVED" section).
+
+### Fix 1 (primary) — silent re-auth on 401, then retry once  ✅ implemented
+
+`src/Pomodoro.Web/Services/GoogleTasksService.cs` (`ExecuteWithRetryAsync`, the 401 catch):
+
+```csharp
+catch (JSException ex) when (ex.Message.Contains("401"))
+{
+    _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
+    if (attempt < maxRetries - 1 && await _googleDriveService.TrySilentAuthAsync())
+    {
+        token = await _googleDriveService.GetAccessTokenAsync();
+        if (string.IsNullOrEmpty(token))
+            throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+        continue; // retry once with the refreshed token
+    }
+    throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+}
+```
+
+`token` is the reassignable loop-local already passed to `action(token)`, so `continue`
+re-runs the request with the fresh token. Only a genuine re-auth failure surfaces as
+`UnauthorizedAccessException`. This removes the 401 storm for the common expired-token case.
+
+Tests: `GetTasksAsync_On401_RetriesAfterSilentReauthSucceeds` (re-auth success → retry
+succeeds) and `GetTasksAsync_On401_ThrowsWhenSilentReauthFails` (re-auth fails → UAE). The
+existing `_ThrowsUnauthorized_On401` cases still pass because the default mock returns
+`false` from `TrySilentAuthAsync()`.
+
+### Fix 2 — handle auth failure distinctly in init (no blind retries; don't kill Drive sync)  ✅ implemented
+
+`src/Pomodoro.Web/Services/CloudSyncService.cs` (`InitializeAsync`): the Tasks pull is
+isolated so a Tasks 401 cannot abort the whole init, and the outer retry no longer fires
+blindly on `UnauthorizedAccessException`:
+
+```csharp
+if (!string.IsNullOrEmpty(ClientId) && syncState.IsConnected)
+{
+    await _googleDriveService.InitializeAsync(ClientId);
+    var authed = await _googleDriveService.TrySilentAuthAsync();
+    if (!authed)
+        SetReconnectRequired(true);
+    _googleDriveService.SetConnected(true);
+    _googleDriveService.SetAccountEmail(syncState.AccountEmail);
+
+    try
+    {
+        await _taskService.RefreshGoogleListsAsync();
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+        _logger.LogWarning(ex, "Google Tasks auth failed during init; Drive sync will continue. Reconnect required.");
+        SetReconnectRequired(true);
+    }
+
+    StartPeriodicSync();   // reached even when Tasks auth failed
+}
+
+// ...
+catch (Exception ex) when (ex is not UnauthorizedAccessException)
+{
+    _logger.LogWarning(ex, "Cloud sync init attempt {Attempt} failed", attempt + 1);
+    if (attempt < 2) await Task.Delay(500);
+}
+```
+
+With Fix 1 in place, the 401 usually self-heals via silent re-auth, so
+`RefreshGoogleListsAsync` typically no longer throws. Fix 2 is defense-in-depth: if Tasks
+auth still fails, Drive periodic sync still starts and init no longer does 3 futile retries.
+
+Test: `InitializeAsync_TasksRefreshUnauthorized_StillInitializesWithoutRetry` — Tasks throw
+UAE, asserts `IsInitialized == true`, `RefreshGoogleListsAsync` called once, and Drive init
+called once (no 3× retry).
+
+### Fix 3 — surface a reconnect prompt  ✅ implemented
+
+A `bool ReconnectRequired` flag on `ICloudSyncService` is set when auth fails (init
+silent-auth failure, init Tasks `UnauthorizedAccessException`, and the `SyncNowAsync` UAE
+catch) and cleared on `ConnectAsync`/`DisconnectAsync` success. `CloudSyncSettings.razor`
+shows a "Google session expired — reconnect" banner + button (calls `ConnectAsync(ClientId)`)
+when the flag is true. `NotifyStatusChanged()` fires on every change so the UI updates.
+
+Tests: `SyncNowAsync_WhenUnauthorizedAccessException_SetsReconnectRequired`,
+`SyncNowAsync_OnSuccessfulSyncAfterFailure_ClearsReconnectRequired`,
+`InitializeAsync_TasksRefreshUnauthorized_StillInitializesWithoutRetry`.
+
+**Post-review guard:** the flag is *also* cleared whenever a sync succeeds
+(`SyncNowAsync` delegates to `ResolveSyncAsync`; on `result.Success` it calls
+`SetReconnectRequired(false)`). Without this, a silent token recovery (the GIS client
+refreshing on its own, or `GoogleTasksService`'s 401 re-auth succeeding) would leave a
+stale "Session expired" banner while syncs were actually completing.
+
+### Fix 4 (design) — stop persisting short-lived access tokens  ✅ implemented
+
+Persisting `syncState.AccessToken` across sessions is the underlying anti-pattern: GIS
+access tokens are ~1h and expire between sessions. Startup now calls
+`TrySilentAuthAsync()` to mint a fresh token rather than restoring a stored bearer that is
+usually already dead. `ConnectAsync` persists state with `SaveSyncStateAsync(connected: true)`
+(no token), and the dead `accessToken` parameter plus the `SyncStateRecord.AccessToken`
+field were removed entirely (no migration needed — JSON deserialization tolerates the
+extra field in existing persisted records). This also orphaned `SetAccessTokenAsync`
+(its sole caller was the removed restore), so the interface/impl method, the
+`googleDrive.setAccessToken` JS function, and the `SetAccessToken` interop constant were
+removed too. On silent-auth failure at startup the flag from Fix 3 prompts reconnect.
+
+## Confirmed root cause #2 (runtime trace, 403) — local tasks hidden by a stale `CurrentListId`  ✅ fixed
+
+This is the actual **"no tasks showing"** symptom (active "Tasks" tab, coral dot, count **11**,
+empty list, no error) — distinct from the 401 storm above, and **not** the `ToDictionary`
+theory (Appendix A): the active list is the *local* Pomodoro list, which never touches the
+sidecar.
+
+The badge and the local-list body use the **identical** predicate
+(`!IsGoogleTask && !IsScheduled && !IsDeleted`): the count at `TaskService.cs:40` and the
+filter at `TaskService.cs:436`. So they cannot diverge by filtering — the only way to get
+badge 11 / list 0 is that the rendered list was fetched for a **different list id** than the
+badge's local list.
+
+```
+Prior session selected a Google list -> _appState.CurrentListId persisted (AppStateRecord)
+  -> next startup restores that Google list id (TaskService.cs:94-96)
+  -> Google pull fails: 401 then 403 (scope) -> GetTaskListsAsync throws at TaskService.cs:483
+  -> the dangling-CurrentListId reset guard (was at :513-520) sits AFTER :483 inside the try,
+     so it never runs; _cachedGoogleLists stays empty
+  -> presenter resolves listId = ActiveListId(null) ?? CurrentListId(dead Google id) ?? local
+     = dead Google id
+  -> GetTasksForListAsync(deadId) filters GoogleListId==deadId -> 0 tasks, no throw
+  -> Index sets Tasks = [] (snapshot) while TaskLists local count = 11 (live)
+  -> badge 11, list empty, no error
+```
+
+**Fix 5 (primary for this symptom)** — sanitize `CurrentListId` regardless of Google-pull
+outcome. Extracted `EnsureCurrentListSelectableAsync()` (resets a Google list id absent from
+`_cachedGoogleLists` back to the local list) and call it:
+- in the not-connected early-return branch,
+- in place of the old inline guard on successful refresh,
+- in a **`finally`** on the refresh `try`, so 401/403/offline/propagated-UAE all still
+  correct the selection.
+
+```csharp
+finally
+{
+    await EnsureCurrentListSelectableAsync(); // runs even when the Google pull throws
+}
+
+private async Task EnsureCurrentListSelectableAsync()
+{
+    var current = _appState.CurrentListId;
+    if (!string.IsNullOrEmpty(current) &&
+        current != Constants.TaskLists.LocalPomodoroListId &&
+        current != Constants.TaskLists.ScheduleListId &&
+        !_cachedGoogleLists.Any(l => l.Id == current))
+    {
+        await SelectListAsync(Constants.TaskLists.LocalPomodoroListId);
+    }
+}
+```
+
+`SelectListAsync` persists the corrected id and fires `NotifyStateChanged`, so the home page
+re-runs `UpdateStateAsync` and renders the 11 local tasks. Build clean.
+
+**Fix 6 (the render fix) — collapse dead list ids at the render boundary**  ✅ implemented
+
+Fix 5 corrected the persisted `_appState.CurrentListId`, but the page's `ActiveListId`
+latched the dead Google id and the presenter preferred it: `Index.razor.cs` passes
+`ActiveListId` as `currentListId`, the resolver is `currentListId ?? CurrentListId ?? local`,
+and `:275` sets `ActiveListId = state.CurrentListId`. Once `ActiveListId = <dead id>` it wins
+over the corrected `CurrentListId` on every refresh → `GetTasksForListAsync(deadId)` → 0
+tasks, no throw → empty list while the badge (a live getter) still shows 11. The latch was
+sticky: even tab clicks kept preferring the latched id.
+
+Two complementary collapses break the latch:
+1. **`IndexPagePresenterService.UpdateStateAsync`** resolves the requested id against
+   `taskService.TaskLists` (always local + schedule + cached Google); a non-member id falls
+   back to local, so both the fetched tasks and the echoed `CurrentListId`/`ActiveListId`
+   revert to local.
+2. **`TaskService.GetTasksForListAsync`** (defense-in-depth) rewrites a non-local,
+   non-schedule, non-cached-Google id to local before filtering.
+
+Tests: `IndexPagePresenterServiceTests.UpdateStateAsync_DeadListId_CollapsesToLocal`,
+`TaskServiceMultiListTests.GetTasksForListAsync_DeadGoogleListId_CollapsesToLocal`. Existing
+`GetTasksForListAsync`/sidecar tests now register their Google list in `_cachedGoogleLists`.
+
+### The 403 itself is configuration, not a code bug
+
+The scope string already requests full tasks scope
+(`googleDrive.js:32`: `…/auth/drive.appdata …/auth/tasks openid email`), yet the call returns
+**403** after a successful silent re-auth. Silent auth (`prompt: none`) **cannot widen an
+existing grant**, so either:
+- the user's existing OAuth grant predates the `auth/tasks` scope → **Disconnect + reconnect**
+  (full consent) to add it; or
+- the **Google Tasks API is not enabled** in the Cloud Console project → enable it.
+
+Fix 5 makes the app usable (local tasks render) regardless; resolving the 403 is what
+re-enables Google lists.
+
+### Fix 6 — collapse a dead list id at the render boundary (Fix 5 alone was insufficient)  ✅ fixed
+
+Fix 5 corrected the **persisted** `_appState.CurrentListId`, but the page still rendered
+empty because the **page's `ActiveListId` latched the dead Google id and overrode the
+correction**:
+
+```
+IndexPagePresenterService resolves: listId = currentListId ?? CurrentListId ?? local
+Index.razor.cs:265 passes ActiveListId as currentListId, and :275 sets ActiveListId = state.CurrentListId
+  -> once ActiveListId == deadGoogleId, it WINS over the Fix 5-corrected _appState.CurrentListId
+  -> every refresh re-fetches the dead list -> GetTasksForListAsync(deadId) -> 0 tasks (no throw)
+  -> task-items stays empty while the local badge counts 11 (live getter)
+```
+
+So the dead id was sticky: even clicking didn't help because the resolver kept preferring the
+latched `ActiveListId`.
+
+Fix: collapse any id that isn't a real list to the local list, at the render boundary, so both
+the fetched tasks **and** the echoed `CurrentListId` (hence `ActiveListId`) revert to local —
+breaking the latch.
+
+`src/Pomodoro.Web/Services/IndexPagePresenterService.cs` (`UpdateStateAsync`):
+
+```csharp
+var requested = currentListId ?? taskService.CurrentListId ?? Constants.TaskLists.LocalPomodoroListId;
+var taskLists = taskService.TaskLists;               // always: local + schedule + cached Google lists
+var listId = taskLists.Any(l => l.Id == requested)   // dead Google id is not a member
+    ? requested
+    : Constants.TaskLists.LocalPomodoroListId;
+var tasks = await taskService.GetTasksForListAsync(listId);
+```
+
+Belt-and-suspenders in `src/Pomodoro.Web/Services/TaskService.cs` (`GetTasksForListAsync`): a
+non-local/non-schedule id absent from `_cachedGoogleLists` is collapsed to the local list
+before filtering, so no caller can bind to an empty dead list while local tasks exist.
+
+Build clean. With Fix 6, `ActiveListId` re-latches to the local list, the local tab highlights,
+and the 11 local tasks render — independent of the Google 401/403.
+
+## Verification
+
+1. **Unit tests**
+   - `RefreshGoogleListsAsync`: when `CurrentListId` is a Google id and the pull throws
+     (401/403) or the user is disconnected, `CurrentListId` resets to the local list
+     (`EnsureCurrentListSelectableAsync` via the `finally`).
+   - `ExecuteWithRetryAsync`: on 401 with `TrySilentAuthAsync()==true`, refreshes token and
+     succeeds on retry; on 401 with silent-auth false, throws `UnauthorizedAccessException` once.
+   - `InitializeAsync`: on `UnauthorizedAccessException` sets reconnect state, does **not**
+     loop 3×, and still starts Drive periodic sync.
+   - `RefreshGoogleListsAsync`: 401 degrades to cached/local without aborting init.
+   - Run: `dotnet test tests/Pomodoro.Web.Tests/Pomodoro.Web.Tests.csproj`
+2. **Manual**: connect, let the token expire (or revoke server-side), reload. Expect one
+   silent re-auth and tasks render — no 401 storm, no "init attempt 3 failed".
+3. **Format / coverage**: `dotnet format Pomodoro.sln --verify-no-changes`; keep ≥99.5% line coverage.
+
+## RESOLVED (2026-06-28): rebuild + restart fixed it — root trigger was a stale build (R0)
+
+After applying Fix 7 and **restarting the running app** at `localhost:7025`, the list renders
+correctly. This confirms the post-Fix-5/6 persistence was **R0: the dev process was serving
+the pre-fix compiled assembly.** Key facts that made this the culprit:
+
+- The dev service worker (`wwwroot/service-worker.js`) explicitly **skips `/_framework/`**
+  (line 119: `request.url.includes('/_framework/') → fetch fresh`), so a browser refresh always
+  fetches the latest WASM/dll **from the server** — but the *server process* must itself be
+  serving the new binary. A `dotnet build` from a side terminal does not restart a separate
+  `dotnet run`/`dotnet watch` already bound to `:7025`; that process keeps executing the old dll.
+- The observed DOM (local "Tasks" tab `aria-selected` + empty list + live badge) is *exactly*
+  the **pre-Fix-6** dead-id state (presenter fetched `ActiveListId=<dead id>` → 0 tasks; the tab
+  highlighted local via `EffectiveCurrentListId` fallback). With Fix 6 compiled in, the first
+  `UpdateStateAsync` collapses the dead id → local and self-heals — so the symptom is
+  impossible on a fresh build, which is why only a restart cleared it.
+
+**Takeaway / repro-avoidance:** after editing C#, restart the process bound to the port (not
+just `dotnet build`), and hard-reload / unregister the SW to drop a cached `index.html`.
+Fix 7 (below) remains a real, kept fix: it guarantees a manual tab click can always recover if
+any future stale-selection state recurs.
+
+## Re-investigation (2026-06-28): why the symptom persisted after Fix 5/6 (superseded by RESOLVED above)
+
+Reported at runtime (localhost:7025): "Tasks" tab is active, coral dot + badge shows **12**,
+but the list is empty, and clicking the Tasks tab shows nothing. A full static re-trace of the
+current code shows **Fix 5 + Fix 6 cannot produce this on the local tab**, so the persistence
+has one of two explanations below — one is environmental, one is a real residual bug.
+
+### Finding R0 — the local path is provably self-consistent (so this is NOT a filter bug)
+
+- Badge count (`TaskService.TaskLists` getter, `TaskService.cs:40`):
+  `allTasks.Count(t => !t.IsGoogleTask && !t.IsScheduled && !t.IsDeleted)`
+- Local-list fetch (`GetTasksForListAsync`, `TaskService.cs:443`):
+  `allTasks.Where(t => !t.IsGoogleTask && !t.IsScheduled && !t.IsDeleted)`
+
+These are **byte-identical**. Plus `IsKnownList` (`:677`) collapses any non-local /
+non-schedule / non-cached-Google id to local, and `TaskService.InitializeAsync` fires
+`NotifyStateChanged()` (`:110`) → `OnTaskServiceChanged` → `UpdateStateAsync`, so the snapshot
+refreshes after load. Therefore, **with the uncommitted Fix 5/6 compiled in, badge-12 /
+list-empty on the local tab is impossible.**
+
+> **Most likely cause of the persistence: the running build is stale.** This is a PWA
+> (`wwwroot/` service worker + JS bundle). The uncommitted fixes only take effect if the app
+> is rebuilt AND the browser isn't serving a cached bundle. Confirm:
+> 1. Stop the server, `dotnet build` (0 errors), then run the freshly built app — not a
+>    previously published artifact or an old `dotnet run`/`dotnet watch` that didn't pick up
+>    edits.
+> 2. Hard-reload / unregister the service worker (DevTools → Application → Service Workers →
+>    Unregister; "Disable cache" on Network) to drop the cached WASM/JS bundle.
+> 3. After that, if the symptom is gone → it was the stale bundle. If it remains → see R1/R2.
+
+### Finding R1 — RESIDUAL BUG (✅ FIXED, Fix 7): the Tasks-tab click was a no-op when `ActiveListId` is stale
+
+`TaskListTabs.razor` (`:36-52`):
+
+```csharp
+private string? EffectiveCurrentListId
+{
+    get
+    {
+        if (CurrentListId != null && VisibleLists.Any(l => l.Id == CurrentListId))
+            return CurrentListId;
+        return VisibleLists.FirstOrDefault()?.Id;   // falls back to the local list
+    }
+}
+
+protected async Task HandleTabClick(string listId)
+{
+    if (listId != EffectiveCurrentListId)          // <-- the guard
+        await OnTabChanged.InvokeAsync(listId);
+}
+```
+
+When `ActiveListId` (= `CurrentListId`) is a **dead Google id**, it is not in `VisibleLists`,
+so `EffectiveCurrentListId` falls back to the **local "Tasks" list** (first visible). Consequence:
+the local tab renders as active (badge 12) and `HandleTabClick(local)` computes
+`local(local) != EffectiveCurrentListId(local)` → **false → `OnTabChanged` never fires**. The
+click is swallowed, `HandleTabChange` / `UpdateStateAsync` never run, and the empty `Tasks`
+snapshot is never refreshed. This is exactly the reported "click the Tasks tab → nothing."
+
+Fix 6 does **not** cover this: the collapse lives inside `UpdateStateAsync`, which the dead
+click never invokes. So once the simultaneous state `ActiveListId=<dead id>` **and**
+`Tasks=<stale empty>` exists, the user cannot click their way out.
+
+**Fix 7 (applied) — click-suppression compares the real id, not the fallback.**
+`src/Pomodoro.Web/Components/Tasks/TaskListTabs.razor` (`HandleTabClick`):
+
+```csharp
+protected async Task HandleTabClick(string listId)
+{
+    if (listId != CurrentListId)        // was: EffectiveCurrentListId (the fallback)
+        await OnTabChanged.InvokeAsync(listId);
+}
+```
+
+`EffectiveCurrentListId` still drives the highlighted/active tab; only the click-suppression
+now uses the real `CurrentListId`. So when `CurrentListId` is a dead id, clicking the
+fallback (local) tab is no longer swallowed — `OnTabChanged` fires → `HandleTabChange` →
+`UpdateStateAsync` runs, Fix 6 collapses the id to local, and the 11/12 local tasks render.
+This gives the user a guaranteed manual recovery even if any future stale-selection state
+recurs. Build clean. **Status: fixed.**
+
+### Finding R2 — RESIDUAL: snapshot `Tasks` vs live badge refresh out of sync
+
+The badge (`TaskLists` getter) is recomputed on **every** render from live `_appState.Tasks`,
+but `Tasks` (the rendered list) is a **snapshot** set only inside `UpdateStateAsync`
+(`Index.razor.cs:267`). Any render that happens in the window between a `_appState.Tasks`
+mutation and the `NotifyStateChanged`-driven `UpdateStateAsync` (e.g. a timer tick calling
+`StateHasChanged`) shows the badge updated to 12 while the list still holds the old (possibly
+empty) snapshot. Transient, but it is the structural reason badge and list can ever disagree
+even with identical predicates. **Status: latent; mitigated by R0/R1.**
+
+### Net assessment
+
+Fix 5/6 make the **code** correct and unit-test-green; **Fix 7 (now applied)** closes the R1
+dead-click so a manual tab click always recovers. With all of Fix 5/6/7 compiled in, the
+local-tab path is provably self-consistent — so if the symptom **still** reproduces, the cause
+is **R0: a stale PWA build/bundle** (the browser is serving a cached WASM/JS bundle or the
+server is running an old artifact). Required next step: rebuild and force the browser to drop
+the cache:
+
+1. Stop the server, `dotnet build` (0 errors), run the **freshly built** app (not an old
+   `dotnet run`/published artifact).
+2. DevTools → Application → Service Workers → **Unregister**; Network → **Disable cache**;
+   then hard-reload.
+3. If the list now renders → it was the stale bundle (R0). If it persists after a verified
+   clean rebuild + SW unregister, capture the console + the `CurrentListId` value and re-open —
+   the code paths for the local tab can no longer produce badge≠list.
+
+## Files touched
+
+- `src/Pomodoro.Web/Services/GoogleTasksService.cs` (Fix 1)
+- `src/Pomodoro.Web/Services/CloudSyncService.cs` (Fix 2, reconnect state)
+- `src/Pomodoro.Web/Services/TaskService.cs` (Fix 5 — `EnsureCurrentListSelectableAsync` + `finally`; Fix 6 — `GetTasksForListAsync` collapse)
+- `src/Pomodoro.Web/Services/IndexPagePresenterService.cs` (Fix 6 — render-boundary collapse; rethrows instead of swallowing)
+- `src/Pomodoro.Web/Components/Tasks/TaskListTabs.razor` (Fix 7 — click-suppression compares real `CurrentListId`, not the fallback)
+- `src/Pomodoro.Web/Pages/Index.razor.cs` + `CloudSyncSettings.razor` (Fix 3 reconnect banner)
+- `src/Pomodoro.Web/Services/IGoogleDriveService.cs` / `GoogleDriveService.cs` / `Constants.JsInterop.cs` / `wwwroot/js/googleDrive.js` (Fix 4 — removed `SetAccessTokenAsync`)
+- `tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs`
+- `tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests*.cs`
+- `tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs`
+- `tests/Pomodoro.Web.Tests/Services/IndexPagePresenterServiceTests.cs`
+
+---
+
+## Appendix A — badge ≠ list via `ToDictionary` crash (prior theory; NOT this trace)
+
+An earlier draft blamed `GetSidecarCacheAsync` `ToDictionary(m => m.GoogleTaskId)`
+(`TaskService.cs:960`) throwing on null/duplicate keys, swallowed by
+`IndexPagePresenterService` (`:36-44`) to produce "badge 11, list empty, no error". The
+runtime trace shows a different failure (a 401 propagating out of `InitializeAsync`), so this
+is not the active cause. The `ToDictionary` hardening is still worthwhile defensively:
+
+```csharp
+_sidecarCache = allMeta
+    .Where(m => !string.IsNullOrEmpty(m.GoogleTaskId))
+    .GroupBy(m => m.GoogleTaskId!)
+    .ToDictionary(g => g.Key, g => g.Last());
+```
+
+## Appendix B — orphan-delete (real, unrelated bug)
+
+`RefreshGoogleListsAsync` (`TaskService.cs:626`) once treated a stored task with `GoogleListId`
+set but `GoogleTaskId == null` as an orphan and soft-deleted it every sync. The
+`t.GoogleTaskId != null` guard fixes it. This drops badge **and** list together (shared
+`!IsDeleted` predicate), so it cannot cause badge ≠ list and is unrelated to the 401 trace.
+Status: guard applied.
+
+## Appendix C — scope gap (only if the error is 403, not 401)
+
+Existing Drive-only users who never consented `tasks.readonly` get **403** (handled at
+`GoogleTasksService.cs:175` → `TasksAccessForbidden`). That needs a re-Connect/re-consent
+prompt, not silent re-auth. Not the current trace (which is 401), but watch for it during
+the Phase 0 scope widen.

--- a/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
+++ b/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
@@ -27,7 +27,7 @@
                     <div class="sr-lbl">Session expired</div>
                     <div class="sr-sub">@Constants.SyncMessages.ReconnectRequired</div>
                 </div>
-                <button class="sec-btn" @onclick="Reconnect" disabled="@_isConnecting">
+                <button class="sec-btn" @onclick="Reconnect" disabled="@(_isConnecting || _isSyncing)">
                     @(_isConnecting ? "Connecting..." : "Reconnect")
                 </button>
             </div>

--- a/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
+++ b/src/Pomodoro.Web/Components/Settings/CloudSyncSettings.razor
@@ -20,6 +20,18 @@
     }
     else
     {
+        @if (CloudSyncService.ReconnectRequired)
+        {
+            <div class="sr reconnect-banner" role="alert">
+                <div>
+                    <div class="sr-lbl">Session expired</div>
+                    <div class="sr-sub">@Constants.SyncMessages.ReconnectRequired</div>
+                </div>
+                <button class="sec-btn" @onclick="Reconnect" disabled="@_isConnecting">
+                    @(_isConnecting ? "Connecting..." : "Reconnect")
+                </button>
+            </div>
+        }
         <div class="sr">
             <div>
                 <div class="sr-lbl">Google Drive</div>
@@ -91,6 +103,8 @@
             StateHasChanged();
         }
     }
+
+    private Task Reconnect() => Connect();
 
     private static string GetSyncSuccessMessage(SyncResult result)
     {

--- a/src/Pomodoro.Web/Components/Tasks/TaskListTabs.razor
+++ b/src/Pomodoro.Web/Components/Tasks/TaskListTabs.razor
@@ -45,7 +45,11 @@
 
     protected async Task HandleTabClick(string listId)
     {
-        if (listId != EffectiveCurrentListId)
+        // Suppress only a re-select of the *actually current* list. Comparing against
+        // EffectiveCurrentListId (which falls back to the first visible list when CurrentListId
+        // is stale/dead) would swallow a click on the fallback tab, leaving the user unable to
+        // refresh out of a stale-selection state. An explicit click must always select.
+        if (listId != CurrentListId)
         {
             await OnTabChanged.InvokeAsync(listId);
         }

--- a/src/Pomodoro.Web/Constants/Constants.JsInterop.cs
+++ b/src/Pomodoro.Web/Constants/Constants.JsInterop.cs
@@ -111,7 +111,6 @@ public static partial class Constants
     {
         public const string Init = "googleDrive.init";
         public const string RequestAuth = "googleDrive.requestAuth";
-        public const string SetAccessToken = "googleDrive.setAccessToken";
         public const string TrySilentAuth = "googleDrive.trySilentAuth";
         public const string RevokeAuth = "googleDrive.revokeAuth";
         public const string IsConnected = "googleDrive.isConnected";

--- a/src/Pomodoro.Web/Constants/Constants.Messages.cs
+++ b/src/Pomodoro.Web/Constants/Constants.Messages.cs
@@ -107,6 +107,7 @@ public static partial class Constants
         public const string ErrorSelectingConsentOption = "Error selecting consent option";
         public const string ErrorCheckingPendingNotificationAction = "Error checking pending notification action";
         public const string ErrorInUpdateState = "Error in UpdateState";
+        public const string ErrorLoadingTasks = "Error loading tasks";
         public const string ErrorInDispose = "Error in Dispose";
         public const string SelectTaskBeforePomodoro = "Please select a task before starting a pomodoro.";
 

--- a/src/Pomodoro.Web/Pages/Index.razor.cs
+++ b/src/Pomodoro.Web/Pages/Index.razor.cs
@@ -274,6 +274,7 @@ public partial class IndexBase : ComponentBase, IDisposable
             TaskLists = state.TaskLists;
             ActiveListId = state.CurrentListId;
             ActiveList = TaskLists.FirstOrDefault(l => l.Id == ActiveListId);
+            ErrorMessage = null;
         }
         catch (Exception ex)
         {

--- a/src/Pomodoro.Web/Pages/Index.razor.cs
+++ b/src/Pomodoro.Web/Pages/Index.razor.cs
@@ -260,24 +260,32 @@ public partial class IndexBase : ComponentBase, IDisposable
 
     private async Task UpdateStateAsync()
     {
-        var state = await IndexPagePresenterService.UpdateStateAsync(TaskService, TimerService, ActiveListId);
+        try
+        {
+            var state = await IndexPagePresenterService.UpdateStateAsync(TaskService, TimerService, ActiveListId);
 
-        Tasks = state.Tasks;
-        CurrentTaskId = state.CurrentTaskId;
-        RemainingTime = state.RemainingTime;
-        CurrentSessionType = state.CurrentSessionType;
-        IsTimerRunning = state.IsTimerRunning;
-        IsTimerPaused = state.IsTimerPaused;
-        IsTimerStarted = state.IsTimerStarted;
-        TaskLists = state.TaskLists;
-        ActiveListId = state.CurrentListId;
-        ActiveList = TaskLists.FirstOrDefault(l => l.Id == ActiveListId);
+            Tasks = state.Tasks;
+            CurrentTaskId = state.CurrentTaskId;
+            RemainingTime = state.RemainingTime;
+            CurrentSessionType = state.CurrentSessionType;
+            IsTimerRunning = state.IsTimerRunning;
+            IsTimerPaused = state.IsTimerPaused;
+            IsTimerStarted = state.IsTimerStarted;
+            TaskLists = state.TaskLists;
+            ActiveListId = state.CurrentListId;
+            ActiveList = TaskLists.FirstOrDefault(l => l.Id == ActiveListId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, Constants.Messages.ErrorInUpdateState);
+            ErrorMessage = $"{Constants.Messages.ErrorLoadingTasks}: {ex.Message}";
+        }
     }
 
     protected async Task HandleTabChange(string listId)
     {
-        await TaskService.SelectListAsync(listId);
         ActiveListId = listId;
+        await TaskService.SelectListAsync(listId);
         await UpdateStateAsync();
     }
 

--- a/src/Pomodoro.Web/Services/CloudSyncService.cs
+++ b/src/Pomodoro.Web/Services/CloudSyncService.cs
@@ -10,6 +10,7 @@ public interface ICloudSyncService
 {
     bool IsConnected { get; }
     bool IsInitialized { get; }
+    bool ReconnectRequired { get; }
     string? ClientId { get; }
     DateTime? LastSyncedAt { get; }
     string DeviceId { get; }
@@ -72,10 +73,12 @@ public class CloudSyncService : ICloudSyncService, IDisposable
     private CancellationTokenSource? _debounceCts;
     private Timer? _periodicSyncTimer;
     private bool _isInitialized;
+    private bool _reconnectRequired;
     private bool _isDisposed;
 
     public bool IsConnected => _googleDriveService.IsConnected;
     public bool IsInitialized => _isInitialized;
+    public bool ReconnectRequired => _reconnectRequired;
     public DateTime? LastSyncedAt { get; private set; }
     private string _deviceId;
     public string DeviceId => _deviceId;
@@ -121,13 +124,22 @@ public class CloudSyncService : ICloudSyncService, IDisposable
                 if (!string.IsNullOrEmpty(ClientId) && syncState.IsConnected)
                 {
                     await _googleDriveService.InitializeAsync(ClientId);
-                    if (!string.IsNullOrEmpty(syncState.AccessToken))
-                    {
-                        await _googleDriveService.SetAccessTokenAsync(syncState.AccessToken);
-                    }
+                    var authed = await _googleDriveService.TrySilentAuthAsync();
+                    if (!authed)
+                        SetReconnectRequired(true);
                     _googleDriveService.SetConnected(true);
                     _googleDriveService.SetAccountEmail(syncState.AccountEmail);
-                    await _taskService.RefreshGoogleListsAsync();
+
+                    try
+                    {
+                        await _taskService.RefreshGoogleListsAsync();
+                    }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        _logger.LogWarning(ex, "Google Tasks auth failed during init; Drive sync will continue. Reconnect required.");
+                        SetReconnectRequired(true);
+                    }
+
                     StartPeriodicSync();
                 }
 
@@ -135,7 +147,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
                 NotifyStatusChanged();
                 return;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not UnauthorizedAccessException)
             {
                 _logger.LogWarning(ex, "Cloud sync init attempt {Attempt} failed", attempt + 1);
                 if (attempt < 2)
@@ -154,11 +166,12 @@ public class CloudSyncService : ICloudSyncService, IDisposable
         try
         {
             await _googleDriveService.InitializeAsync(clientId);
-            var token = await _googleDriveService.ConnectAsync();
+            _ = await _googleDriveService.ConnectAsync();
 
             ClientId = clientId;
-            await SaveSyncStateAsync(connected: true, accessToken: token);
+            await SaveSyncStateAsync(connected: true);
 
+            SetReconnectRequired(false);
             StartPeriodicSync();
             await _taskService.RefreshGoogleListsAsync();
             NotifyStatusChanged();
@@ -193,6 +206,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
 
         ClientId = null;
         LastSyncedAt = null;
+        SetReconnectRequired(false);
         await SaveSyncStateAsync(connected: false);
         NotifyStatusChanged();
     }
@@ -206,40 +220,21 @@ public class CloudSyncService : ICloudSyncService, IDisposable
 
         try
         {
-            var fileId = await _googleDriveService.FindSyncFileAsync();
+            var result = await ResolveSyncAsync();
 
-            if (fileId == null)
+            // A successful sync means the session recovered (e.g. the GIS token
+            // client silently refreshed the token); clear any stale reconnect banner.
+            if (result.Success)
             {
-                return await PushAsync();
+                SetReconnectRequired(false);
             }
 
-            var remoteJson = await _googleDriveService.ReadFileAsync(fileId);
-            var remoteEnvelope = JsonSerializer.Deserialize<SyncEnvelope>(remoteJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-
-            if (remoteEnvelope == null)
-            {
-                return await PushAsync();
-            }
-
-            var remoteLastSynced = remoteEnvelope.LastSyncedAt;
-
-            if (LastSyncedAt == null || remoteLastSynced > LastSyncedAt)
-            {
-                return await PullAsync(fileId, remoteEnvelope);
-            }
-
-            if (LastSyncedAt > remoteLastSynced)
-            {
-                return await PushAsync(fileId);
-            }
-
-            _logger.LogInformation(Constants.SyncMessages.LogDataEqual);
-            return SyncResult.UpToDate();
+            return result;
         }
         catch (UnauthorizedAccessException)
         {
             _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
-            await SaveSyncStateAsync(accessToken: null);
+            SetReconnectRequired(true);
             return SyncResult.Failed(Constants.SyncMessages.ReconnectRequired);
         }
         catch (Exception ex)
@@ -247,6 +242,39 @@ public class CloudSyncService : ICloudSyncService, IDisposable
             _logger.LogError(ex, Constants.SyncMessages.LogSyncFailed, ex.Message);
             return SyncResult.Failed(ex.Message);
         }
+    }
+
+    private async Task<SyncResult> ResolveSyncAsync()
+    {
+        var fileId = await _googleDriveService.FindSyncFileAsync();
+
+        if (fileId == null)
+        {
+            return await PushAsync();
+        }
+
+        var remoteJson = await _googleDriveService.ReadFileAsync(fileId);
+        var remoteEnvelope = JsonSerializer.Deserialize<SyncEnvelope>(remoteJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (remoteEnvelope == null)
+        {
+            return await PushAsync();
+        }
+
+        var remoteLastSynced = remoteEnvelope.LastSyncedAt;
+
+        if (LastSyncedAt == null || remoteLastSynced > LastSyncedAt)
+        {
+            return await PullAsync(fileId, remoteEnvelope);
+        }
+
+        if (LastSyncedAt > remoteLastSynced)
+        {
+            return await PushAsync(fileId);
+        }
+
+        _logger.LogInformation(Constants.SyncMessages.LogDataEqual);
+        return SyncResult.UpToDate();
     }
 
     public Task SyncInBackgroundAsync()
@@ -439,7 +467,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
         }
     }
 
-    private async Task SaveSyncStateAsync(bool? connected = null, string? accessToken = null)
+    private async Task SaveSyncStateAsync(bool? connected = null)
     {
         try
         {
@@ -449,7 +477,6 @@ public class CloudSyncService : ICloudSyncService, IDisposable
                 LastSyncedAt = LastSyncedAt,
                 DeviceId = DeviceId,
                 IsConnected = connected ?? IsConnected,
-                AccessToken = accessToken,
                 AccountEmail = _googleDriveService.AccountEmail
             };
             await _indexedDb.PutAsync(Constants.Storage.AppStateStore, state);
@@ -461,6 +488,13 @@ public class CloudSyncService : ICloudSyncService, IDisposable
     }
 
     private void NotifyStatusChanged() => OnSyncStatusChanged?.Invoke();
+
+    private void SetReconnectRequired(bool value)
+    {
+        if (_reconnectRequired == value) return;
+        _reconnectRequired = value;
+        NotifyStatusChanged();
+    }
 
     public void Dispose()
     {
@@ -488,6 +522,5 @@ public class SyncStateRecord
     public DateTime? LastSyncedAt { get; set; }
     public string? DeviceId { get; set; }
     public bool IsConnected { get; set; }
-    public string? AccessToken { get; set; }
     public string? AccountEmail { get; set; }
 }

--- a/src/Pomodoro.Web/Services/CloudSyncService.cs
+++ b/src/Pomodoro.Web/Services/CloudSyncService.cs
@@ -169,7 +169,6 @@ public class CloudSyncService : ICloudSyncService, IDisposable
             _ = await _googleDriveService.ConnectAsync();
 
             ClientId = clientId;
-            await SaveSyncStateAsync(connected: true);
 
             SetReconnectRequired(false);
             StartPeriodicSync();
@@ -181,6 +180,8 @@ public class CloudSyncService : ICloudSyncService, IDisposable
             {
                 _logger.LogWarning(Constants.SyncMessages.LogSyncFailed, syncResult.ErrorMessage);
             }
+
+            await SaveSyncStateAsync(connected: true);
 
             return true;
         }
@@ -222,8 +223,6 @@ public class CloudSyncService : ICloudSyncService, IDisposable
         {
             var result = await ResolveSyncAsync();
 
-            // A successful sync means the session recovered (e.g. the GIS token
-            // client silently refreshed the token); clear any stale reconnect banner.
             if (result.Success)
             {
                 SetReconnectRequired(false);
@@ -358,7 +357,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
             _logger.LogInformation(Constants.SyncMessages.LogSyncComplete);
             return SyncResult.Pushed();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not UnauthorizedAccessException)
         {
             _logger.LogError(ex, Constants.SyncMessages.LogSyncFailed, ex.Message);
             return SyncResult.Failed(ex.Message);
@@ -402,7 +401,7 @@ public class CloudSyncService : ICloudSyncService, IDisposable
                 result.TasksImported, result.TasksSkipped,
                 result.SettingsImported);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not UnauthorizedAccessException)
         {
             _logger.LogError(ex, Constants.SyncMessages.LogSyncFailed, ex.Message);
             return SyncResult.Failed(ex.Message);

--- a/src/Pomodoro.Web/Services/GoogleDriveService.cs
+++ b/src/Pomodoro.Web/Services/GoogleDriveService.cs
@@ -23,12 +23,6 @@ public class GoogleDriveService : IGoogleDriveService
 
     public void SetAccountEmail(string? email) => _accountEmail = email;
 
-    public async Task SetAccessTokenAsync(string token)
-    {
-        await _jsRuntime.InvokeVoidAsync(Constants.GoogleDriveJsFunctions.SetAccessToken, token);
-        _isConnected = true;
-    }
-
     public async Task<bool> TrySilentAuthAsync()
     {
         try

--- a/src/Pomodoro.Web/Services/GoogleTasksService.cs
+++ b/src/Pomodoro.Web/Services/GoogleTasksService.cs
@@ -165,6 +165,13 @@ public class GoogleTasksService : IGoogleTasksService
             catch (JSException ex) when (ex.Message.Contains("401"))
             {
                 _logger.LogWarning(Constants.SyncMessages.LogSyncUnauthorized);
+                if (attempt < maxRetries - 1 && await _googleDriveService.TrySilentAuthAsync())
+                {
+                    token = await _googleDriveService.GetAccessTokenAsync();
+                    if (string.IsNullOrEmpty(token))
+                        throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
+                    continue;
+                }
                 throw new UnauthorizedAccessException(Constants.SyncMessages.TasksReconnectRequired, ex);
             }
             catch (JSException ex) when (ex.Message.Contains("412"))

--- a/src/Pomodoro.Web/Services/IGoogleDriveService.cs
+++ b/src/Pomodoro.Web/Services/IGoogleDriveService.cs
@@ -5,7 +5,6 @@ public interface IGoogleDriveService
     Task InitializeAsync(string clientId);
     Task<bool> TrySilentAuthAsync();
     void SetConnected(bool connected);
-    Task SetAccessTokenAsync(string token);
     Task<string?> ConnectAsync();
     Task DisconnectAsync();
     bool IsConnected { get; }

--- a/src/Pomodoro.Web/Services/IndexPagePresenterService.cs
+++ b/src/Pomodoro.Web/Services/IndexPagePresenterService.cs
@@ -19,10 +19,6 @@ public class IndexPagePresenterService
         {
             var requested = currentListId ?? taskService.CurrentListId ?? Constants.TaskLists.LocalPomodoroListId;
 
-            // Collapse a stale/dead list id (e.g. a Google list restored from storage that is
-            // no longer available after a failed sync) to the local list. Otherwise the page
-            // binds to an empty list while local tasks exist (badge shows a count, list empty),
-            // and ActiveListId latches the dead id on every subsequent refresh.
             var taskLists = taskService.TaskLists;
             var listId = taskLists.Any(l => l.Id == requested)
                 ? requested

--- a/src/Pomodoro.Web/Services/IndexPagePresenterService.cs
+++ b/src/Pomodoro.Web/Services/IndexPagePresenterService.cs
@@ -17,7 +17,17 @@ public class IndexPagePresenterService
     {
         try
         {
-            var listId = currentListId ?? taskService.CurrentListId ?? Constants.TaskLists.LocalPomodoroListId;
+            var requested = currentListId ?? taskService.CurrentListId ?? Constants.TaskLists.LocalPomodoroListId;
+
+            // Collapse a stale/dead list id (e.g. a Google list restored from storage that is
+            // no longer available after a failed sync) to the local list. Otherwise the page
+            // binds to an empty list while local tasks exist (badge shows a count, list empty),
+            // and ActiveListId latches the dead id on every subsequent refresh.
+            var taskLists = taskService.TaskLists;
+            var listId = taskLists.Any(l => l.Id == requested)
+                ? requested
+                : Constants.TaskLists.LocalPomodoroListId;
+
             var tasks = await taskService.GetTasksForListAsync(listId);
 
             return new IndexPageState
@@ -35,19 +45,8 @@ public class IndexPagePresenterService
         }
         catch (Exception ex)
         {
-            var fallbackListId = currentListId ?? taskService.CurrentListId ?? Constants.TaskLists.LocalPomodoroListId;
             _logger.LogError(ex, "Error in UpdateStateAsync");
-            return new IndexPageState
-            {
-                Tasks = new List<TaskItem>(),
-                TaskLists = taskService.TaskLists,
-                RemainingTime = timerService.RemainingTime,
-                CurrentSessionType = timerService.CurrentSessionType,
-                IsTimerRunning = timerService.IsRunning,
-                IsTimerPaused = timerService.IsPaused,
-                IsTimerStarted = timerService.IsStarted,
-                CurrentListId = fallbackListId
-            };
+            throw;
         }
     }
 }

--- a/src/Pomodoro.Web/Services/TaskService.cs
+++ b/src/Pomodoro.Web/Services/TaskService.cs
@@ -430,8 +430,6 @@ public class TaskService : ITaskService, ITimerEventSubscriber
 
     public async Task<IReadOnlyList<TaskItem>> GetTasksForListAsync(string listId)
     {
-        // Defense-in-depth: a dead Google list id (not local/schedule and not in the cached
-        // Google lists) must not silently return empty while local tasks exist.
         if (!IsKnownList(listId))
         {
             listId = Constants.TaskLists.LocalPomodoroListId;
@@ -517,8 +515,6 @@ public class TaskService : ITaskService, ITimerEventSubscriber
             await SaveGoogleTasksSettingsAsync();
             await SaveGoogleListsCacheAsync();
             InvalidateSidecarCache();
-
-            await EnsureCurrentListSelectableAsync();
 
             foreach (var gList in remoteLists)
             {
@@ -624,7 +620,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                         }
                     }
 
-                    foreach (var orphan in existingInList.Where(t => t.GoogleTaskId != null && !remoteIds.Contains(t.GoogleTaskId)))
+                    foreach (var orphan in existingInList.Where(t => !string.IsNullOrEmpty(t.GoogleTaskId) && !remoteIds.Contains(t.GoogleTaskId)))
                     {
                         var deleted = orphan.WithUpdates(c =>
                         {
@@ -651,16 +647,10 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         }
         finally
         {
-            // Runs even when the Google pull throws (401/403/offline) or propagates
-            // UnauthorizedAccessException: a stale Google CurrentListId restored from
-            // storage must fall back to the local list, otherwise the home list binds
-            // to an unavailable Google list (0 tasks) while the badge counts local tasks.
             await EnsureCurrentListSelectableAsync();
         }
     }
 
-    // Resets a dangling CurrentListId (a Google list id no longer present in the cached
-    // lists) back to the local Pomodoro list. Safe no-op for local/schedule/known-Google ids.
     private async Task EnsureCurrentListSelectableAsync()
     {
         var current = _appState.CurrentListId;
@@ -670,10 +660,6 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         }
     }
 
-    // Single source of truth for "is this a selectable list": the two built-in lists or a
-    // currently-cached Google list. Routing both GetTasksForListAsync and
-    // EnsureCurrentListSelectableAsync through this prevents the built-in-list predicate from
-    // drifting across sites if a new built-in list is added later.
     private bool IsKnownList(string? listId) =>
         listId == Constants.TaskLists.LocalPomodoroListId ||
         listId == Constants.TaskLists.ScheduleListId ||

--- a/src/Pomodoro.Web/Services/TaskService.cs
+++ b/src/Pomodoro.Web/Services/TaskService.cs
@@ -430,6 +430,13 @@ public class TaskService : ITaskService, ITimerEventSubscriber
 
     public async Task<IReadOnlyList<TaskItem>> GetTasksForListAsync(string listId)
     {
+        // Defense-in-depth: a dead Google list id (not local/schedule and not in the cached
+        // Google lists) must not silently return empty while local tasks exist.
+        if (!IsKnownList(listId))
+        {
+            listId = Constants.TaskLists.LocalPomodoroListId;
+        }
+
         var allTasks = _appState.Tasks;
         IEnumerable<TaskItem> filtered = listId switch
         {
@@ -475,6 +482,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         if (!await _googleTasksService.IsConnectedAsync())
         {
             _cachedGoogleLists = [];
+            await EnsureCurrentListSelectableAsync();
             return;
         }
 
@@ -510,14 +518,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
             await SaveGoogleListsCacheAsync();
             InvalidateSidecarCache();
 
-            if (remoteLists.Count > 0 &&
-                !string.IsNullOrEmpty(_appState.CurrentListId) &&
-                _appState.CurrentListId != Constants.TaskLists.LocalPomodoroListId &&
-                _appState.CurrentListId != Constants.TaskLists.ScheduleListId &&
-                !updatedCache.Any(l => l.Id == _appState.CurrentListId))
-            {
-                await SelectListAsync(Constants.TaskLists.LocalPomodoroListId);
-            }
+            await EnsureCurrentListSelectableAsync();
 
             foreach (var gList in remoteLists)
             {
@@ -623,7 +624,7 @@ public class TaskService : ITaskService, ITimerEventSubscriber
                         }
                     }
 
-                    foreach (var orphan in existingInList.Where(t => !remoteIds.Contains(t.GoogleTaskId)))
+                    foreach (var orphan in existingInList.Where(t => t.GoogleTaskId != null && !remoteIds.Contains(t.GoogleTaskId)))
                     {
                         var deleted = orphan.WithUpdates(c =>
                         {
@@ -648,7 +649,35 @@ public class TaskService : ITaskService, ITimerEventSubscriber
         {
             _logger.LogWarning(ex, "Failed to refresh Google task lists");
         }
+        finally
+        {
+            // Runs even when the Google pull throws (401/403/offline) or propagates
+            // UnauthorizedAccessException: a stale Google CurrentListId restored from
+            // storage must fall back to the local list, otherwise the home list binds
+            // to an unavailable Google list (0 tasks) while the badge counts local tasks.
+            await EnsureCurrentListSelectableAsync();
+        }
     }
+
+    // Resets a dangling CurrentListId (a Google list id no longer present in the cached
+    // lists) back to the local Pomodoro list. Safe no-op for local/schedule/known-Google ids.
+    private async Task EnsureCurrentListSelectableAsync()
+    {
+        var current = _appState.CurrentListId;
+        if (!string.IsNullOrEmpty(current) && !IsKnownList(current))
+        {
+            await SelectListAsync(Constants.TaskLists.LocalPomodoroListId);
+        }
+    }
+
+    // Single source of truth for "is this a selectable list": the two built-in lists or a
+    // currently-cached Google list. Routing both GetTasksForListAsync and
+    // EnsureCurrentListSelectableAsync through this prevents the built-in-list predicate from
+    // drifting across sites if a new built-in list is added later.
+    private bool IsKnownList(string? listId) =>
+        listId == Constants.TaskLists.LocalPomodoroListId ||
+        listId == Constants.TaskLists.ScheduleListId ||
+        _cachedGoogleLists.Any(l => l.Id == listId);
 
     private async Task SaveTaskAsync(TaskItem task)
     {
@@ -957,7 +986,10 @@ public class TaskService : ITaskService, ITimerEventSubscriber
             return _sidecarCache!;
 
         var allMeta = await _sidecarRepo.GetAllAsync();
-        _sidecarCache = allMeta.ToDictionary(m => m.GoogleTaskId);
+        _sidecarCache = allMeta
+            .Where(m => !string.IsNullOrEmpty(m.GoogleTaskId))
+            .GroupBy(m => m.GoogleTaskId)
+            .ToDictionary(g => g.Key, g => g.Last());
         _sidecarCacheDirty = false;
         return _sidecarCache;
     }

--- a/src/Pomodoro.Web/wwwroot/css/settings.css
+++ b/src/Pomodoro.Web/wwwroot/css/settings.css
@@ -45,6 +45,18 @@
     margin-top: 1px;
 }
 
+.reconnect-banner {
+    padding: 7px 10px;
+    background: rgba(229, 152, 53, 0.12);
+    border: 0.5px solid rgba(229, 152, 53, 0.5);
+    border-radius: 6px;
+    margin: 2px 0;
+}
+
+.reconnect-banner .sr-lbl {
+    color: #e59835;
+}
+
 /* Stepper Control */
 .stepper {
     display: flex;

--- a/src/Pomodoro.Web/wwwroot/js/googleDrive.js
+++ b/src/Pomodoro.Web/wwwroot/js/googleDrive.js
@@ -110,10 +110,6 @@ window.googleDrive = {
         return this._accessToken !== null && this._accessToken !== undefined;
     },
 
-    setAccessToken: function(token) {
-        this._accessToken = token;
-    },
-
     getAccessToken: function() {
         return this._accessToken;
     },

--- a/tests/Pomodoro.Web.Tests/Pages/IndexTasksTests.cs
+++ b/tests/Pomodoro.Web.Tests/Pages/IndexTasksTests.cs
@@ -317,5 +317,24 @@ public class IndexTasksTests : TestHelper
     }
 
     #endregion
+
+    #region HandleTabChange
+
+    [Fact]
+    public async Task HandleTabChange_CallsTaskServiceSelectListAsync_WhenInvoked()
+    {
+        const string listId = Constants.TaskLists.LocalPomodoroListId;
+        var cut = RenderComponent<Pomodoro.Web.Pages.Index>();
+
+        var method = typeof(IndexBase).GetMethod(
+            "HandleTabChange",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var task = (Task)method!.Invoke(cut.Instance, new object[] { listId })!;
+        await task;
+
+        TaskServiceMock.Verify(x => x.SelectListAsync(listId), Times.Once);
+    }
+
+    #endregion
 }
 

--- a/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
@@ -180,6 +180,7 @@ public class CloudSyncServiceTests : IDisposable
         await _sut.InitializeAsync();
 
         Assert.True(_sut.IsInitialized);
+        Assert.True(_sut.ReconnectRequired);
         _mockTaskService.Verify(t => t.RefreshGoogleListsAsync(), Times.Once);
         _mockGoogleDrive.Verify(g => g.InitializeAsync("test-client-id"), Times.Once);
     }

--- a/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/CloudSyncServiceTests.cs
@@ -128,18 +128,18 @@ public class CloudSyncServiceTests : IDisposable
         var state = new SyncStateRecord
         {
             ClientId = "test-client-id",
-            IsConnected = true,
-            AccessToken = "test-token"
+            IsConnected = true
         };
         _mockIndexedDb
             .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
             .ReturnsAsync(state);
         _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
+        _mockGoogleDrive.Setup(g => g.TrySilentAuthAsync()).ReturnsAsync(true);
 
         await _sut.InitializeAsync();
 
         _mockGoogleDrive.Verify(g => g.InitializeAsync("test-client-id"), Times.Once);
-        _mockGoogleDrive.Verify(g => g.SetAccessTokenAsync("test-token"), Times.Once);
+        _mockGoogleDrive.Verify(g => g.TrySilentAuthAsync(), Times.Once);
         _mockGoogleDrive.Verify(g => g.SetConnected(true), Times.Once);
     }
 
@@ -149,8 +149,7 @@ public class CloudSyncServiceTests : IDisposable
         var state = new SyncStateRecord
         {
             ClientId = "test-client-id",
-            IsConnected = true,
-            AccessToken = "test-token"
+            IsConnected = true
         };
         _mockIndexedDb
             .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
@@ -160,6 +159,29 @@ public class CloudSyncServiceTests : IDisposable
         await _sut.InitializeAsync();
 
         Assert.True(_sut.IsConnected);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_TasksRefreshUnauthorized_StillInitializesWithoutRetry()
+    {
+        var state = new SyncStateRecord
+        {
+            ClientId = "test-client-id",
+            IsConnected = true
+        };
+        _mockIndexedDb
+            .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
+            .ReturnsAsync(state);
+        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
+        _mockTaskService
+            .Setup(t => t.RefreshGoogleListsAsync())
+            .ThrowsAsync(new UnauthorizedAccessException("Token expired"));
+
+        await _sut.InitializeAsync();
+
+        Assert.True(_sut.IsInitialized);
+        _mockTaskService.Verify(t => t.RefreshGoogleListsAsync(), Times.Once);
+        _mockGoogleDrive.Verify(g => g.InitializeAsync("test-client-id"), Times.Once);
     }
 
     [Fact]
@@ -185,8 +207,7 @@ public class CloudSyncServiceTests : IDisposable
         var state = new SyncStateRecord
         {
             ClientId = "test-client-id",
-            IsConnected = true,
-            AccessToken = "test-token"
+            IsConnected = true
         };
         _mockIndexedDb
             .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
@@ -223,8 +244,7 @@ public class CloudSyncServiceTests : IDisposable
         var state = new SyncStateRecord
         {
             ClientId = "test-client-id",
-            IsConnected = true,
-            AccessToken = "test-token"
+            IsConnected = true
         };
         _mockIndexedDb
             .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
@@ -291,25 +311,6 @@ public class CloudSyncServiceTests : IDisposable
         await _sut.InitializeAsync();
 
         Assert.Equal(originalDeviceId, _sut.DeviceId);
-    }
-
-    [Fact]
-    public async Task InitializeAsync_WithEmptyAccessToken_DoesNotSetAccessToken()
-    {
-        var state = new SyncStateRecord
-        {
-            ClientId = "test-client-id",
-            IsConnected = true,
-            AccessToken = null
-        };
-        _mockIndexedDb
-            .Setup(db => db.GetAsync<SyncStateRecord>(Constants.Storage.AppStateStore, "cloudSync"))
-            .ReturnsAsync(state);
-        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
-
-        await _sut.InitializeAsync();
-
-        _mockGoogleDrive.Verify(g => g.SetAccessTokenAsync(It.IsAny<string>()), Times.Never);
     }
 
     #endregion
@@ -712,7 +713,7 @@ public class CloudSyncServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SyncNowAsync_WhenUnauthorizedAccessException_ClearsAccessToken()
+    public async Task SyncNowAsync_WhenUnauthorizedAccessException_SetsReconnectRequired()
     {
         _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
         _mockGoogleDrive.Setup(g => g.FindSyncFileAsync())
@@ -720,10 +721,34 @@ public class CloudSyncServiceTests : IDisposable
 
         await _sut.SyncNowAsync();
 
-        _mockIndexedDb.Verify(
-            db => db.PutAsync(Constants.Storage.AppStateStore, It.Is<SyncStateRecord>(s =>
-                s.AccessToken == null)),
-            Times.Once);
+        Assert.True(_sut.ReconnectRequired);
+    }
+
+    [Fact]
+    public async Task SyncNowAsync_OnSuccessfulSyncAfterFailure_ClearsReconnectRequired()
+    {
+        _mockGoogleDrive.Setup(g => g.IsConnected).Returns(true);
+
+        // First sync fails with auth error -> banner raised.
+        _mockGoogleDrive.Setup(g => g.FindSyncFileAsync())
+            .ThrowsAsync(new UnauthorizedAccessException("Token expired"));
+        await _sut.SyncNowAsync();
+        Assert.True(_sut.ReconnectRequired);
+
+        // Token silently recovers -> next sync succeeds and clears the banner.
+        _mockGoogleDrive.Setup(g => g.FindSyncFileAsync()).ReturnsAsync((string?)null);
+        _mockExportService.Setup(e => e.ExportToJsonStringAsync()).ReturnsAsync("{}");
+        _mockJsRuntime.Setup(js => js.InvokeAsync<string>(
+            Constants.CompressionJsFunctions.GzipCompress, It.IsAny<object?[]>()))
+            .ReturnsAsync("compressed");
+        _mockGoogleDrive.Setup(g => g.CreateFileAsync(
+            Constants.Sync.SyncFileName, It.IsAny<string>()))
+            .ReturnsAsync("file-id");
+
+        var result = await _sut.SyncNowAsync();
+
+        Assert.True(result.Success);
+        Assert.False(_sut.ReconnectRequired);
     }
 
     [Fact]

--- a/tests/Pomodoro.Web.Tests/Services/GoogleDriveServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/GoogleDriveServiceTests.cs
@@ -90,16 +90,6 @@ public class GoogleDriveServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SetAccessTokenAsync_InvokesJs()
-    {
-        await _service.SetAccessTokenAsync("my-token");
-
-        Assert.Equal("googleDrive.setAccessToken", _jsRuntime.LastMethod);
-        Assert.Equal("my-token", _jsRuntime.LastArgs?[0]);
-        Assert.True(_service.IsConnected);
-    }
-
-    [Fact]
     public async Task TrySilentAuthAsync_InvokesJs()
     {
         _jsRuntime.NextResult = "silent-token";

--- a/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
@@ -157,6 +157,20 @@ public class GoogleTasksServiceTests
     }
 
     [Fact]
+    public async Task GetTasksAsync_On401_ThrowsWhenSilentReauthSucceedsButTokenEmpty()
+    {
+        _jsRuntime.QueueException(new JSException("Error 401: Unauthorized"));
+        _googleDriveServiceMock.Setup(x => x.TrySilentAuthAsync()).ReturnsAsync(true);
+        _googleDriveServiceMock.SetupSequence(x => x.GetAccessTokenAsync())
+            .ReturnsAsync("stale-token")
+            .ReturnsAsync((string?)null);
+
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _service.GetTasksAsync("list-1"));
+        Assert.Contains("reconnect", ex.Message.ToLower());
+        _googleDriveServiceMock.Verify(x => x.TrySilentAuthAsync(), Times.Once);
+    }
+
+    [Fact]
     public async Task GetTasksAsync_Retries_On429()
     {
         _jsRuntime.QueueException(new JSException("Error 429: Too Many Requests"));

--- a/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/GoogleTasksServiceTests.cs
@@ -124,6 +124,39 @@ public class GoogleTasksServiceTests
     }
 
     [Fact]
+    public async Task GetTasksAsync_On401_RetriesAfterSilentReauthSucceeds()
+    {
+        _jsRuntime.QueueException(new JSException("Error 401: Unauthorized"));
+        var responseJson = JsonSerializer.Serialize(new[]
+        {
+            new { id = "t1", title = "After reauth", status = "needsAction", updated = "2026-01-01T00:00:00.000Z" }
+        });
+        _jsRuntime.QueueResult(responseJson);
+
+        _googleDriveServiceMock.Setup(x => x.TrySilentAuthAsync()).ReturnsAsync(true);
+        _googleDriveServiceMock.SetupSequence(x => x.GetAccessTokenAsync())
+            .ReturnsAsync("stale-token")
+            .ReturnsAsync("fresh-token");
+
+        var tasks = await _service.GetTasksAsync("list-1");
+
+        Assert.Single(tasks);
+        Assert.Equal("After reauth", tasks[0].Title);
+        _googleDriveServiceMock.Verify(x => x.TrySilentAuthAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTasksAsync_On401_ThrowsWhenSilentReauthFails()
+    {
+        _jsRuntime.QueueException(new JSException("Error 401: Unauthorized"));
+        _googleDriveServiceMock.Setup(x => x.TrySilentAuthAsync()).ReturnsAsync(false);
+
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => _service.GetTasksAsync("list-1"));
+        Assert.Contains("reconnect", ex.Message.ToLower());
+        _googleDriveServiceMock.Verify(x => x.TrySilentAuthAsync(), Times.Once);
+    }
+
+    [Fact]
     public async Task GetTasksAsync_Retries_On429()
     {
         _jsRuntime.QueueException(new JSException("Error 429: Too Many Requests"));

--- a/tests/Pomodoro.Web.Tests/Services/IndexPagePresenterServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/IndexPagePresenterServiceTests.cs
@@ -90,10 +90,11 @@ public class IndexPagePresenterServiceTests
             new(Constants.TaskLists.LocalPomodoroListId, "Tasks", "var(--pomodoro-color)", 0, true, true)
         });
         taskService.Setup(s => s.GetTasksForListAsync(It.IsAny<string>()))
-            .ThrowsAsync(new Exception("Test exception"));
+            .ThrowsAsync(new InvalidOperationException("Test exception"));
         var timerService = SetupTimerService(TimeSpan.FromMinutes(5), SessionType.ShortBreak, true, true, true);
 
-        await Assert.ThrowsAsync<Exception>(() => _service.UpdateStateAsync(taskService.Object, timerService.Object, null));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.UpdateStateAsync(taskService.Object, timerService.Object, null));
+        Assert.Equal("Test exception", ex.Message);
     }
 
     [Fact]
@@ -155,7 +156,6 @@ public class IndexPagePresenterServiceTests
         var taskService = SetupTaskService(localTasks);
         var timerService = SetupTimerService();
 
-        // "glist-gone" is not a member of TaskLists (only the local list is known) -> collapse.
         var result = await _service.UpdateStateAsync(taskService.Object, timerService.Object, "glist-gone");
 
         taskService.Verify(s => s.GetTasksForListAsync(Constants.TaskLists.LocalPomodoroListId), Times.Once);

--- a/tests/Pomodoro.Web.Tests/Services/IndexPagePresenterServiceTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/IndexPagePresenterServiceTests.cs
@@ -82,22 +82,18 @@ public class IndexPagePresenterServiceTests
     }
 
     [Fact]
-    public async Task UpdateStateAsync_WithException_ShouldReturnDefaultState()
+    public async Task UpdateStateAsync_WithException_ShouldRethrow()
     {
         var taskService = new Mock<ITaskService>();
+        taskService.Setup(s => s.TaskLists).Returns(new List<TaskListRef>
+        {
+            new(Constants.TaskLists.LocalPomodoroListId, "Tasks", "var(--pomodoro-color)", 0, true, true)
+        });
         taskService.Setup(s => s.GetTasksForListAsync(It.IsAny<string>()))
             .ThrowsAsync(new Exception("Test exception"));
         var timerService = SetupTimerService(TimeSpan.FromMinutes(5), SessionType.ShortBreak, true, true, true);
 
-        var result = await _service.UpdateStateAsync(taskService.Object, timerService.Object, null);
-
-        Assert.Empty(result.Tasks);
-        Assert.Equal(TimeSpan.FromMinutes(5), result.RemainingTime);
-        Assert.Equal(SessionType.ShortBreak, result.CurrentSessionType);
-        Assert.True(result.IsTimerRunning);
-        Assert.True(result.IsTimerPaused);
-        Assert.True(result.IsTimerStarted);
-        Assert.Equal(Constants.TaskLists.LocalPomodoroListId, result.CurrentListId);
+        await Assert.ThrowsAsync<Exception>(() => _service.UpdateStateAsync(taskService.Object, timerService.Object, null));
     }
 
     [Fact]
@@ -119,6 +115,11 @@ public class IndexPagePresenterServiceTests
     public async Task UpdateStateAsync_PassesListIdToTaskService()
     {
         var taskService = SetupTaskService();
+        taskService.Setup(s => s.TaskLists).Returns(new List<TaskListRef>
+        {
+            new("custom-list-id", "Custom", "var(--pomodoro-color)", 0, true, true),
+            new(Constants.TaskLists.LocalPomodoroListId, "Tasks", "var(--pomodoro-color)", 0, true, true)
+        });
         var timerService = SetupTimerService();
 
         await _service.UpdateStateAsync(taskService.Object, timerService.Object, "custom-list-id");
@@ -131,12 +132,35 @@ public class IndexPagePresenterServiceTests
     {
         var taskService = SetupTaskService();
         taskService.Setup(s => s.CurrentListId).Returns("glist-1");
+        taskService.Setup(s => s.TaskLists).Returns(new List<TaskListRef>
+        {
+            new("glist-1", "Google", "var(--pomodoro-color)", 0, true, true),
+            new(Constants.TaskLists.LocalPomodoroListId, "Tasks", "var(--pomodoro-color)", 0, true, true)
+        });
         var timerService = SetupTimerService();
 
         var result = await _service.UpdateStateAsync(taskService.Object, timerService.Object, null);
 
         taskService.Verify(s => s.GetTasksForListAsync("glist-1"), Times.Once);
         Assert.Equal("glist-1", result.CurrentListId);
+    }
+
+    [Fact]
+    public async Task UpdateStateAsync_DeadListId_CollapsesToLocal()
+    {
+        var localTasks = new List<TaskItem>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Local", CreatedAt = DateTime.UtcNow }
+        };
+        var taskService = SetupTaskService(localTasks);
+        var timerService = SetupTimerService();
+
+        // "glist-gone" is not a member of TaskLists (only the local list is known) -> collapse.
+        var result = await _service.UpdateStateAsync(taskService.Object, timerService.Object, "glist-gone");
+
+        taskService.Verify(s => s.GetTasksForListAsync(Constants.TaskLists.LocalPomodoroListId), Times.Once);
+        Assert.Equal(Constants.TaskLists.LocalPomodoroListId, result.CurrentListId);
+        Assert.Single(result.Tasks);
     }
 
     [Fact]

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
@@ -209,6 +209,7 @@ public class TaskServiceMultiListTests
         _mockSidecarRepo.Setup(x => x.GetAllAsync()).ReturnsAsync(metaList);
 
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
         var result = await sut.GetTasksForListAsync("glist-1");
 
         result.Should().HaveCount(2);
@@ -504,6 +505,37 @@ public class TaskServiceMultiListTests
     }
 
     [Fact]
+    public async Task RefreshGoogleListsAsync_PullThrowsUnauthorized_ResetsStaleGoogleListToLocal()
+    {
+        _appState.CurrentListId = "glist-gone";
+
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ThrowsAsync(new UnauthorizedAccessException("401 Unauthorized"));
+
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => sut.RefreshGoogleListsAsync());
+
+        _appState.CurrentListId.Should().Be(Constants.TaskLists.LocalPomodoroListId);
+    }
+
+    [Fact]
+    public async Task RefreshGoogleListsAsync_PullFailsNonAuth_SwallowsAndResetsStaleListToLocal()
+    {
+        _appState.CurrentListId = "glist-gone";
+
+        _mockGoogleTasksService.Setup(x => x.IsConnectedAsync()).ReturnsAsync(true);
+        _mockGoogleTasksService.Setup(x => x.GetTaskListsAsync())
+            .ThrowsAsync(new InvalidOperationException("offline"));
+
+        var sut = CreateSut();
+        await sut.RefreshGoogleListsAsync();
+
+        _appState.CurrentListId.Should().Be(Constants.TaskLists.LocalPomodoroListId);
+    }
+
+    [Fact]
     public async Task RefreshGoogleListsAsync_DeletesOrphans_RemoteRemoved()
     {
         var localTask = new TaskItem
@@ -623,7 +655,8 @@ public class TaskServiceMultiListTests
         var sut = CreateSut();
         await sut.InitializeAsync();
 
-        _appState.CurrentListId.Should().Be("glist-1");
+        // glist-1 is no longer present remotely -> Fix 5 resets to the local list
+        _appState.CurrentListId.Should().Be(Constants.TaskLists.LocalPomodoroListId);
     }
 
     [Fact]
@@ -649,6 +682,7 @@ public class TaskServiceMultiListTests
         _mockSidecarRepo.Setup(x => x.GetAllAsync()).ReturnsAsync([]);
 
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
         var result = await sut.GetTasksForListAsync("glist-1");
 
         result.Should().HaveCount(1);
@@ -874,11 +908,42 @@ public class TaskServiceMultiListTests
             [new PomodoroMeta("gtask-1", 5, 125, Priority.High)]);
 
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
 
         await sut.GetTasksForListAsync("glist-1");
         await sut.GetTasksForListAsync("glist-1");
 
         _mockSidecarRepo.Verify(x => x.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTasksForListAsync_ToleratesNullAndDuplicateSidecarKeys()
+    {
+        var task = new TaskItem
+        {
+            Id = Guid.NewGuid(),
+            Name = "Google Task",
+            GoogleTaskId = "gtask-1",
+            GoogleListId = "glist-1",
+            CreatedAt = DateTime.UtcNow
+        };
+        _appState.Tasks = [task];
+        _mockSidecarRepo.Setup(x => x.GetAllAsync()).ReturnsAsync(
+            new List<PomodoroMeta>
+            {
+                new("gtask-1", 1, 25, Priority.Med),
+                new("gtask-1", 2, 50, Priority.High),
+                new(null!, 9, 999, Priority.High)
+            });
+
+        var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
+        var result = await sut.GetTasksForListAsync("glist-1");
+
+        var hydrated = result.Should().HaveCount(1).And.Subject.First();
+        hydrated.PomodoroCount.Should().Be(2);
+        hydrated.TotalFocusMinutes.Should().Be(50);
+        hydrated.Priority.Should().Be(Priority.High);
     }
 
     [Fact]
@@ -1243,11 +1308,31 @@ public class TaskServiceMultiListTests
         _appState.Tasks = tasks;
         _mockSidecarRepo.Setup(x => x.GetAllAsync()).ReturnsAsync([]);
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [
+            new GoogleListCacheEntry("glist-1", "List 1", "var(--pomodoro-color)", true),
+            new GoogleListCacheEntry("glist-2", "List 2", "var(--pomodoro-color)", true)
+        ]);
 
         var result = await sut.GetTasksForListAsync("glist-1");
 
         result.Should().HaveCount(1);
         result[0].Name.Should().Be("Google");
+    }
+
+    [Fact]
+    public async Task GetTasksForListAsync_DeadGoogleListId_CollapsesToLocal()
+    {
+        var localTask = new TaskItem { Id = Guid.NewGuid(), Name = "Local", CreatedAt = DateTime.UtcNow };
+        var googleTask = new TaskItem { Id = Guid.NewGuid(), Name = "Google", GoogleTaskId = "gt-1", GoogleListId = "glist-gone", CreatedAt = DateTime.UtcNow };
+        _appState.Tasks = [localTask, googleTask];
+        _mockSidecarRepo.Setup(x => x.GetAllAsync()).ReturnsAsync([]);
+
+        var sut = CreateSut();
+
+        var result = await sut.GetTasksForListAsync("glist-gone");
+
+        result.Should().HaveCount(1);
+        result[0].Name.Should().Be("Local");
     }
 
     [Fact]

--- a/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
+++ b/tests/Pomodoro.Web.Tests/Services/TaskServiceMultiListTests.cs
@@ -241,6 +241,7 @@ public class TaskServiceMultiListTests
             [new PomodoroMeta("gtask-1", 3, 75, Priority.High)]);
 
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
         await sut.GetTasksForListAsync("glist-1");
 
         var originalTask = _appState.FindTaskById(task.Id);
@@ -439,6 +440,7 @@ public class TaskServiceMultiListTests
         _appState.Tasks = [localTask];
 
         var sut = CreateSut();
+        SetCachedGoogleLists(sut, [new GoogleListCacheEntry("glist-1", "List", "var(--pomodoro-color)", true)]);
         var result = await sut.GetTasksForListAsync("glist-1");
 
         result.Should().HaveCount(1);
@@ -655,7 +657,6 @@ public class TaskServiceMultiListTests
         var sut = CreateSut();
         await sut.InitializeAsync();
 
-        // glist-1 is no longer present remotely -> Fix 5 resets to the local list
         _appState.CurrentListId.Should().Be(Constants.TaskLists.LocalPomodoroListId);
     }
 

--- a/tests/e2e/pages/google-tasks-connect.spec.ts
+++ b/tests/e2e/pages/google-tasks-connect.spec.ts
@@ -26,7 +26,6 @@ test.describe('Google Tasks Connect Flow', () => {
         const gd = (window as any).googleDrive;
         if (gd) {
           gd.init = () => Promise.resolve();
-          gd.setAccessToken = () => Promise.resolve();
           gd.getAccessToken = () => Promise.resolve('mock-access-token');
           gd.isConnected = () => true;
           gd.findSyncFile = () => Promise.resolve(null);


### PR DESCRIPTION
## Summary

Resolves the home **Tasks tab showing a count badge while the list renders empty**, plus the **startup Google-sync 401 storm** that disabled all sync. A full causal trace is in `docs/fixes/tasks-not-rendering.md`.

## Root causes (two distinct)

1. **401 storm on startup** — an expired persisted access token was never refreshed; the 401 handler threw instead of silently re-authing, and the failure aborted the whole sync init (including Drive).
2. **Empty Tasks list with a live badge** — a stale Google `CurrentListId` restored from storage pointed the page at a dead list; `ActiveListId` latched it and the render boundary preferred it, so the list fetched 0 tasks while the badge counted live local tasks.

## Changes

- **Fix 1** — `GoogleTasksService` silently re-auths and retries once on a 401.
- **Fix 2** — `CloudSyncService.InitializeAsync` isolates the Tasks pull so a Tasks 401/403 no longer aborts Drive sync init or triggers 3 futile retries.
- **Fix 3** — `ReconnectRequired` flag surfaced as a "Session expired — Reconnect" banner in Cloud Sync settings; cleared on connect/disconnect and on any successful sync.
- **Fix 4** — stop persisting short-lived tokens; startup mints a fresh token via `TrySilentAuthAsync`. Removes the dead `SyncStateRecord.AccessToken` field + `SetAccessTokenAsync` interop.
- **Fix 5** — `EnsureCurrentListSelectableAsync` resets a stale Google `CurrentListId` to local (called in a `finally`, so 401/403/offline all correct it).
- **Fix 6** — collapse dead list ids to local at the render boundary (presenter + `GetTasksForListAsync`).
- **Fix 7** — `TaskListTabs` click guard compares against the real `CurrentListId`, not the `EffectiveCurrentListId` fallback, so the Tasks tab is never a dead click.

## Verification

- `dotnet build` — 0 errors
- `dotnet format Pomodoro.sln --verify-no-changes` — clean
- `dotnet test` — **3616/3616 passing**

## Follow-up (tracked separately)

A residual gap remains on the **Connect** path: a Tasks-only 403 (scope gap) still aborts the whole `ConnectAsync` (Drive included). This will be addressed on a separate branch.

## Notes

- The 403 (insufficient `auth/tasks` scope) is a **configuration** issue, not a code bug — resolved by revoking access and reconnecting with full consent, or enabling the Google Tasks API in GCP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Session expired” reconnect banner in cloud sync settings with a one-click reconnect action.

* **Bug Fixes**
  * Improved Google Tasks/Drive sync recovery from expired sessions without disrupting other cloud sync activity.
  * Fixed task tab selection behavior when the current list state is stale/invalid.
  * Ensured task list selection and error handling reset reliably, including safer fallback to local tasks.

* **Documentation**
  * Added a manual test checklist and a detailed troubleshooting report for the tasks-not-rendering / Google sync startup issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #110
